### PR TITLE
refactor: JWT 인증 모듈 common으로 이동 및 의존성 구조 정리

### DIFF
--- a/modi/build.gradle
+++ b/modi/build.gradle
@@ -31,6 +31,8 @@ subprojects {
         implementation 'org.springframework.boot:spring-boot-starter-actuator'
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+        implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
         implementation 'org.springframework.boot:spring-boot-starter-security'
         implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
         implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/modi/common/src/main/java/com/coc/modi/common/auth/JwtAuthenticationFilter.java
+++ b/modi/common/src/main/java/com/coc/modi/common/auth/JwtAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package com.coc.modi.auth.infrastructure.jwt;
+package com.coc.modi.common.auth;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/modi/common/src/main/java/com/coc/modi/common/auth/JwtTokenProvider.java
+++ b/modi/common/src/main/java/com/coc/modi/common/auth/JwtTokenProvider.java
@@ -1,9 +1,8 @@
-package com.coc.modi.auth.infrastructure.jwt;
+package com.coc.modi.common.auth;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 

--- a/modi/common/src/main/java/com/coc/modi/common/auth/SecurityConfig.java
+++ b/modi/common/src/main/java/com/coc/modi/common/auth/SecurityConfig.java
@@ -1,6 +1,5 @@
-package com.coc.modi.auth.config;
+package com.coc.modi.common.auth;
 
-import com.coc.modi.auth.infrastructure.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/modi/member-service/src/main/java/com/coc/modi/auth/application/MemberAuthService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/application/MemberAuthService.java
@@ -3,7 +3,7 @@ package com.coc.modi.auth.application;
 import com.coc.modi.auth.application.dto.MemberLoginCommand;
 import com.coc.modi.auth.application.dto.MemberLoginResponse;
 import com.coc.modi.auth.presentation.dto.MemberLoginInfo;
-import com.coc.modi.auth.infrastructure.jwt.JwtTokenProvider;
+import com.coc.modi.common.auth.JwtTokenProvider;
 import com.coc.modi.member.domain.Member;
 import com.coc.modi.member.infrastructure.MemberRepository;
 import lombok.RequiredArgsConstructor;

--- a/modi/member-service/src/main/java/com/coc/modi/member/MemberServiceApplication.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/MemberServiceApplication.java
@@ -9,7 +9,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication(scanBasePackages = "com.coc.modi")
+@SpringBootApplication(scanBasePackages = {"com.coc.modi"})
 @EnableJpaAuditing
 @SecurityScheme(
         name = "BearerAuth",

--- a/modi/member-service/src/main/java/com/coc/modi/member/domain/Member.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/domain/Member.java
@@ -6,8 +6,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Getter
 @Entity
 @Table(name = "member", schema = "public")
@@ -18,33 +16,28 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 100)
+    @Column(nullable = false, length = 255, unique = true)
     private String email;
 
-    @Column(nullable = false, length = 255)
-    private String password;
-
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false, length = 100)
     private String name;
-
-    @Column(length = 20)
-    private String phone;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
-    private MemberRole role;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private MemberStatus status;
 
-    @Column(nullable = false)
-    private boolean emailVerified;
+    @Column(nullable = false, length = 255)
+    private String password;
 
-    private LocalDateTime lastLoginAt;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private MemberRole role;
+
+    @Column(nullable = false, length = 20)
+    private String phone;
 
     @Column(length = 20)
-    private String provider; // GOOGLE, KAKAO, NAVER
+    private String provider;
 
     @Column(length = 100)
     private String providerId;
@@ -60,7 +53,6 @@ public class Member extends BaseEntity {
         this.phone = phone;
         this.role = role;
         this.status = MemberStatus.ACTIVE;
-        this.emailVerified = false;
     }
 
     public static Member create(String email,


### PR DESCRIPTION
- 기존 member-service에 있던 JwtTokenProvider, JwtAuthenticationFilter 등 인증 관련 코드를 common 모듈로 이동
- 각 서비스에서 공통 사용 가능하도록 common 모듈 의존성 추가
- MemberRepository 구조 분리 (MemberJpaRepository, MemberRepository 인터페이스 생성)
- 빌드 경로 및 import 구조 수정