### PR TITLE
feat: member-service 회원 정보 수정, 비밀번호 변경, 탈퇴 및 회원가입시 이메일 인증 기능 구현

### DIFF
--- a/modi/build.gradle
+++ b/modi/build.gradle
@@ -4,6 +4,10 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
+ext {
+    set('springCloudVersion', '2025.0.0')
+}
+
 group = 'com.coc'
 version = '0.0.1-SNAPSHOT'
 description = 'modi'
@@ -30,9 +34,7 @@ subprojects {
         implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-actuator'
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-
         implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
-
         implementation 'org.springframework.boot:spring-boot-starter-security'
         implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
         implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
@@ -43,6 +45,12 @@ subprojects {
         testCompileOnly 'org.projectlombok:lombok'
         testAnnotationProcessor 'org.projectlombok:lombok'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    }
+
+    dependencyManagement {
+        imports {
+            mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+        }
     }
 
     tasks.named('test') {

--- a/modi/member-service/build.gradle
+++ b/modi/member-service/build.gradle
@@ -1,9 +1,13 @@
 dependencies {
     implementation project(':common')
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     runtimeOnly 'org.postgresql:postgresql'
 }

--- a/modi/member-service/build.gradle
+++ b/modi/member-service/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     implementation project(':common')
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'

--- a/modi/member-service/src/main/java/com/coc/modi/auth/application/EmailVerificationService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/application/EmailVerificationService.java
@@ -1,0 +1,94 @@
+package com.coc.modi.auth.application;
+
+import com.coc.modi.auth.application.dto.ConfirmEmailVerificationCommand;
+import com.coc.modi.auth.application.dto.SendEmailVerificationCommand;
+import com.coc.modi.auth.domain.EmailVerification;
+import com.coc.modi.auth.domain.EmailVerificationRepository;
+import com.coc.modi.auth.infrastructure.mail.EmailSender;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+	
+	private static final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
+	private static final Pattern CODE_PATTERN = Pattern.compile("^\\d{6}$");
+	private static final int CODE_BOUND = 1_000_000;
+	private static final long EXPIRATION_MINUTES = 5L;
+	
+	private final EmailVerificationRepository emailVerificationRepository;
+	private final EmailSender emailSender;
+	private final SecureRandom secureRandom = new SecureRandom();
+	
+	// 이메일 인증 코드 발송
+	@Transactional
+	public void sendVerificationEmail(SendEmailVerificationCommand command) {
+		
+		validateEmail(command.email());
+		
+		String code = generateCode();
+		LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES);
+		
+		emailVerificationRepository.findByEmail(command.email())
+				.ifPresentOrElse(existing -> existing.regenerate(code, expiresAt),
+						() -> emailVerificationRepository.save(
+								EmailVerification.create(command.email(), code, expiresAt)
+						));
+		
+		emailSender.sendVerificationCode(command.email(), code);
+	}
+	
+	// 이메일 인증 코드 검증
+	@Transactional
+	public boolean confirmVerification(ConfirmEmailVerificationCommand command) {
+		
+		validateEmail(command.email());
+		validateCode(command.code());
+		
+		EmailVerification emailVerification = emailVerificationRepository.findByEmail(command.email())
+				.orElseThrow(() -> new IllegalArgumentException("이메일 인증 요청이 존재하지 않습니다."));
+		
+		emailVerification.verify(command.code(), LocalDateTime.now());
+		
+		return true;
+	}
+	
+	private String generateCode() {
+		
+		return String.format("%06d", secureRandom.nextInt(CODE_BOUND));
+	}
+	
+	private void validateEmail(String email) {
+		
+		if (email == null || email.isBlank()) {
+			
+			throw new IllegalArgumentException("이메일을 입력해주세요.");
+		}
+		
+		if (!EMAIL_PATTERN.matcher(email).matches()) {
+			
+			throw new IllegalArgumentException("이메일 형식이 올바르지 않습니다.");
+		}
+	}
+	
+	private void validateCode(String code) {
+		
+		if (code == null || code.isBlank()) {
+			
+			throw new IllegalArgumentException("인증 코드를 입력해주세요.");
+		}
+		
+		if (!CODE_PATTERN.matcher(code).matches()) {
+			
+			throw new IllegalArgumentException("인증 코드는 6자리 숫자입니다.");
+		}
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/auth/application/EmailVerificationService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/application/EmailVerificationService.java
@@ -5,6 +5,8 @@ import com.coc.modi.auth.application.dto.SendEmailVerificationCommand;
 import com.coc.modi.auth.domain.EmailVerification;
 import com.coc.modi.auth.domain.EmailVerificationRepository;
 import com.coc.modi.auth.infrastructure.mail.EmailSender;
+import com.coc.modi.auth.presentation.dto.EmailVerificationSendResponse;
+import com.coc.modi.auth.presentation.dto.EmailVerificationConfirmResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,12 +27,12 @@ public class EmailVerificationService {
 	private static final long EXPIRATION_MINUTES = 5L;
 	
 	private final EmailVerificationRepository emailVerificationRepository;
-	private final EmailSender emailSender;
 	private final SecureRandom secureRandom = new SecureRandom();
+	private final EmailSender emailSender;
 	
 	// 이메일 인증 코드 발송
 	@Transactional
-	public void sendVerificationEmail(SendEmailVerificationCommand command) {
+	public EmailVerificationSendResponse sendVerificationEmail(SendEmailVerificationCommand command) {
 		
 		validateEmail(command.email());
 		
@@ -44,11 +46,13 @@ public class EmailVerificationService {
 						));
 		
 		emailSender.sendVerificationCode(command.email(), code);
+		
+		return EmailVerificationSendResponse.success();
 	}
 	
 	// 이메일 인증 코드 검증
 	@Transactional
-	public boolean confirmVerification(ConfirmEmailVerificationCommand command) {
+	public EmailVerificationConfirmResponse confirmVerification(ConfirmEmailVerificationCommand command) {
 		
 		validateEmail(command.email());
 		validateCode(command.code());
@@ -58,7 +62,7 @@ public class EmailVerificationService {
 		
 		emailVerification.verify(command.code(), LocalDateTime.now());
 		
-		return true;
+		return EmailVerificationConfirmResponse.success();
 	}
 	
 	private String generateCode() {

--- a/modi/member-service/src/main/java/com/coc/modi/auth/application/MemberAuthService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/application/MemberAuthService.java
@@ -2,7 +2,6 @@ package com.coc.modi.auth.application;
 
 import com.coc.modi.auth.application.dto.MemberLoginCommand;
 import com.coc.modi.auth.application.dto.MemberLoginResponse;
-import com.coc.modi.auth.presentation.dto.MemberLoginInfo;
 import com.coc.modi.common.auth.JwtTokenProvider;
 import com.coc.modi.member.domain.Member;
 import com.coc.modi.member.infrastructure.MemberRepository;
@@ -18,7 +17,7 @@ public class MemberAuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
-
+    // 로그인
     public MemberLoginResponse login(MemberLoginCommand command) {
 
         // TODO : 나중에 커스텀 예외로 변경
@@ -32,13 +31,17 @@ public class MemberAuthService {
         String accessToken = jwtTokenProvider.generateAccessToken(member.getId(), member.getRole().name());
         String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId(), member.getRole().name());
 
-        MemberLoginInfo memberInfo = new MemberLoginInfo(
+        MemberLoginResponse.MemberData memberData = new MemberLoginResponse.MemberData(
                 member.getId(),
                 member.getEmail(),
                 member.getName(),
                 member.getRole().name()
         );
 
-        return new MemberLoginResponse(accessToken, refreshToken, memberInfo);
+        return new MemberLoginResponse(
+                accessToken,
+                refreshToken,
+                memberData
+        );
     }
 }

--- a/modi/member-service/src/main/java/com/coc/modi/auth/application/MemberAuthService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/application/MemberAuthService.java
@@ -31,17 +31,6 @@ public class MemberAuthService {
         String accessToken = jwtTokenProvider.generateAccessToken(member.getId(), member.getRole().name());
         String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId(), member.getRole().name());
 
-        MemberLoginResponse.MemberData memberData = new MemberLoginResponse.MemberData(
-                member.getId(),
-                member.getEmail(),
-                member.getName(),
-                member.getRole().name()
-        );
-
-        return new MemberLoginResponse(
-                accessToken,
-                refreshToken,
-                memberData
-        );
+        return MemberLoginResponse.of(accessToken, refreshToken, member);
     }
 }

--- a/modi/member-service/src/main/java/com/coc/modi/auth/application/MemberAuthService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/application/MemberAuthService.java
@@ -4,7 +4,7 @@ import com.coc.modi.auth.application.dto.MemberLoginCommand;
 import com.coc.modi.auth.application.dto.MemberLoginResponse;
 import com.coc.modi.common.auth.JwtTokenProvider;
 import com.coc.modi.member.domain.Member;
-import com.coc.modi.member.infrastructure.MemberRepository;
+import com.coc.modi.member.domain.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/modi/member-service/src/main/java/com/coc/modi/auth/application/MemberAuthService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/application/MemberAuthService.java
@@ -5,32 +5,34 @@ import com.coc.modi.auth.application.dto.MemberLoginResponse;
 import com.coc.modi.common.auth.JwtTokenProvider;
 import com.coc.modi.member.domain.Member;
 import com.coc.modi.member.domain.MemberRepository;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class MemberAuthService {
-
-    private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
-    private final JwtTokenProvider jwtTokenProvider;
-
-    // 로그인
-    public MemberLoginResponse login(MemberLoginCommand command) {
-
-        // TODO : 나중에 커스텀 예외로 변경
-        Member member = memberRepository.findByEmail(command.email())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
-
-        if (!passwordEncoder.matches(command.password(), member.getPassword())) {
-            throw new IllegalArgumentException("비밀번호 불일치입니다.");
-        }
-
-        String accessToken = jwtTokenProvider.generateAccessToken(member.getId(), member.getRole().name());
-        String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId(), member.getRole().name());
-
-        return MemberLoginResponse.of(accessToken, refreshToken, member);
-    }
+	
+	private final MemberRepository memberRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtTokenProvider jwtTokenProvider;
+	
+	// 로그인
+	public MemberLoginResponse login(MemberLoginCommand command) {
+		
+		// TODO : 나중에 커스텀 예외로 변경
+		Member member = memberRepository.findByEmail(command.email())
+				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+		
+		if (!passwordEncoder.matches(command.password(), member.getPassword())) {
+			throw new IllegalArgumentException("비밀번호 불일치입니다.");
+		}
+		
+		String accessToken = jwtTokenProvider.generateAccessToken(member.getId(), member.getRole().name());
+		String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId(), member.getRole().name());
+		
+		return MemberLoginResponse.of(accessToken, refreshToken, member);
+	}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/auth/application/MemberAuthService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/application/MemberAuthService.java
@@ -27,6 +27,7 @@ public class MemberAuthService {
 				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 		
 		if (!passwordEncoder.matches(command.password(), member.getPassword())) {
+			
 			throw new IllegalArgumentException("비밀번호 불일치입니다.");
 		}
 		

--- a/modi/member-service/src/main/java/com/coc/modi/auth/application/dto/ConfirmEmailVerificationCommand.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/application/dto/ConfirmEmailVerificationCommand.java
@@ -1,0 +1,7 @@
+package com.coc.modi.auth.application.dto;
+
+public record ConfirmEmailVerificationCommand(
+		String email,
+		String code
+) {
+}

--- a/modi/member-service/src/main/java/com/coc/modi/auth/application/dto/MemberLoginCommand.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/application/dto/MemberLoginCommand.java
@@ -1,7 +1,7 @@
 package com.coc.modi.auth.application.dto;
 
 public record MemberLoginCommand(
-        String email,
-        String password
+		String email,
+		String password
 ) {
 }

--- a/modi/member-service/src/main/java/com/coc/modi/auth/application/dto/MemberLoginResponse.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/application/dto/MemberLoginResponse.java
@@ -3,37 +3,37 @@ package com.coc.modi.auth.application.dto;
 import com.coc.modi.member.domain.Member;
 
 public record MemberLoginResponse(
-        String accessToken,
-        String refreshToken,
-        MemberData member
+		String accessToken,
+		String refreshToken,
+		MemberData member
 ) {
-    public static MemberLoginResponse of(
-            String accessToken,
-            String refreshToken,
-            Member member
-    ) {
-
-        return new MemberLoginResponse(
-                accessToken,
-                refreshToken,
-                MemberData.from(member)
-        );
-    }
-
-    public record MemberData(
-            Long id,
-            String email,
-            String name,
-            String role
-    ) {
-        public static MemberData from(Member member) {
-
-            return new MemberData(
-                    member.getId(),
-                    member.getEmail(),
-                    member.getName(),
-                    member.getRole().name()
-            );
-        }
-    }
+	public static MemberLoginResponse of(
+			String accessToken,
+			String refreshToken,
+			Member member
+	) {
+		
+		return new MemberLoginResponse(
+				accessToken,
+				refreshToken,
+				MemberData.from(member)
+		);
+	}
+	
+	public record MemberData(
+			Long id,
+			String email,
+			String name,
+			String role
+	) {
+		public static MemberData from(Member member) {
+			
+			return new MemberData(
+					member.getId(),
+					member.getEmail(),
+					member.getName(),
+					member.getRole().name()
+			);
+		}
+	}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/auth/application/dto/MemberLoginResponse.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/application/dto/MemberLoginResponse.java
@@ -1,10 +1,14 @@
 package com.coc.modi.auth.application.dto;
 
-import com.coc.modi.auth.presentation.dto.MemberLoginInfo;
-
 public record MemberLoginResponse (
         String accessToken,
         String refreshToken,
-        MemberLoginInfo member
+        MemberData member
 ){
+    public record MemberData (
+            Long id,
+            String email,
+            String name,
+            String role
+    ){}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/auth/application/dto/MemberLoginResponse.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/application/dto/MemberLoginResponse.java
@@ -1,14 +1,39 @@
 package com.coc.modi.auth.application.dto;
 
-public record MemberLoginResponse (
+import com.coc.modi.member.domain.Member;
+
+public record MemberLoginResponse(
         String accessToken,
         String refreshToken,
         MemberData member
-){
-    public record MemberData (
+) {
+    public static MemberLoginResponse of(
+            String accessToken,
+            String refreshToken,
+            Member member
+    ) {
+
+        return new MemberLoginResponse(
+                accessToken,
+                refreshToken,
+                MemberData.from(member)
+        );
+    }
+
+    public record MemberData(
             Long id,
             String email,
             String name,
             String role
-    ){}
+    ) {
+        public static MemberData from(Member member) {
+
+            return new MemberData(
+                    member.getId(),
+                    member.getEmail(),
+                    member.getName(),
+                    member.getRole().name()
+            );
+        }
+    }
 }

--- a/modi/member-service/src/main/java/com/coc/modi/auth/application/dto/SendEmailVerificationCommand.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/application/dto/SendEmailVerificationCommand.java
@@ -1,0 +1,6 @@
+package com.coc.modi.auth.application.dto;
+
+public record SendEmailVerificationCommand(
+        String email
+) {
+}

--- a/modi/member-service/src/main/java/com/coc/modi/auth/domain/EmailVerification.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/domain/EmailVerification.java
@@ -1,0 +1,79 @@
+package com.coc.modi.auth.domain;
+
+import com.coc.modi.common.BaseEntity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "email_verification", schema = "public")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailVerification extends BaseEntity {
+	
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	@Column(nullable = false, length = 320, unique = true)
+	private String email;
+	
+	@Column(nullable = false, length = 10)
+	private String code;
+	
+	@Column(nullable = false)
+	private LocalDateTime expiresAt;
+	
+	@Column(nullable = false)
+	private boolean verified;
+	
+	private EmailVerification(String email,
+							  String code,
+							  LocalDateTime expiresAt) {
+		
+		this.email = email;
+		this.code = code;
+		this.expiresAt = expiresAt;
+		this.verified = false;
+	}
+	
+	public static EmailVerification create(String email,
+										   String code,
+										   LocalDateTime expiresAt) {
+		
+		return new EmailVerification(email, code, expiresAt);
+	}
+	
+	public void regenerate(String code,
+						   LocalDateTime expiresAt) {
+		
+		this.code = code;
+		this.expiresAt = expiresAt;
+		this.verified = false;
+	}
+	
+	public void verify(String code,
+					   LocalDateTime currentTime) {
+		
+		if (isExpired(currentTime)) {
+			
+			throw new IllegalArgumentException("인증 코드가 만료되었습니다.");
+		}
+		
+		if (!this.code.equals(code)) {
+			
+			throw new IllegalArgumentException("인증 코드가 일치하지 않습니다.");
+		}
+		
+		this.verified = true;
+	}
+	
+	private boolean isExpired(LocalDateTime currentTime) {
+		
+		return currentTime.isAfter(expiresAt);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/auth/domain/EmailVerificationRepository.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/domain/EmailVerificationRepository.java
@@ -1,0 +1,10 @@
+package com.coc.modi.auth.domain;
+
+import java.util.Optional;
+
+public interface EmailVerificationRepository {
+	
+	Optional<EmailVerification> findByEmail(String email);
+	
+	EmailVerification save(EmailVerification emailVerification);
+}

--- a/modi/member-service/src/main/java/com/coc/modi/auth/infrastructure/EmailVerificationJpaRepository.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/infrastructure/EmailVerificationJpaRepository.java
@@ -1,0 +1,12 @@
+package com.coc.modi.auth.infrastructure;
+
+import com.coc.modi.auth.domain.EmailVerification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmailVerificationJpaRepository extends JpaRepository<EmailVerification, Long> {
+	
+	Optional<EmailVerification> findByEmail(String email);
+}

--- a/modi/member-service/src/main/java/com/coc/modi/auth/infrastructure/EmailVerificationRepositoryAdapter.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/infrastructure/EmailVerificationRepositoryAdapter.java
@@ -1,0 +1,29 @@
+package com.coc.modi.auth.infrastructure;
+
+import com.coc.modi.auth.domain.EmailVerification;
+import com.coc.modi.auth.domain.EmailVerificationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class EmailVerificationRepositoryAdapter implements EmailVerificationRepository {
+	
+	private final EmailVerificationJpaRepository emailVerificationJpaRepository;
+	
+	@Override
+	public Optional<EmailVerification> findByEmail(String email) {
+		
+		return emailVerificationJpaRepository.findByEmail(email);
+	}
+	
+	@Override
+	public EmailVerification save(EmailVerification emailVerification) {
+		
+		return emailVerificationJpaRepository.save(emailVerification);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/auth/infrastructure/mail/EmailSender.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/infrastructure/mail/EmailSender.java
@@ -1,0 +1,45 @@
+package com.coc.modi.auth.infrastructure.mail;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+public class EmailSender {
+	
+	private final JavaMailSender mailSender;
+	
+	@Value("${mail.from-address:}")
+	private String fromAddress;
+	
+	public void sendVerificationCode(String to, String code) {
+		
+		if (!StringUtils.hasText(fromAddress)) {
+			
+			throw new IllegalStateException("메일 발신 주소가 설정되지 않았습니다.");
+		}
+		
+		SimpleMailMessage message = new SimpleMailMessage();
+		message.setTo(to);
+		message.setFrom(fromAddress);
+		message.setSubject("MODI 이메일 인증 코드");
+		message.setText(buildBody(code));
+		
+		mailSender.send(message);
+	}
+	
+	private String buildBody(String code) {
+		
+		return """
+				안녕하세요, MODI입니다.
+				
+				요청하신 인증 코드는 [%s] 입니다.
+				5분 안에 입력해 주세요.
+				""".formatted(code);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/auth/infrastructure/mail/EmailSender.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/infrastructure/mail/EmailSender.java
@@ -25,6 +25,7 @@ public class EmailSender {
 		}
 		
 		SimpleMailMessage message = new SimpleMailMessage();
+		
 		message.setTo(to);
 		message.setFrom(fromAddress);
 		message.setSubject("MODI 이메일 인증 코드");

--- a/modi/member-service/src/main/java/com/coc/modi/auth/presentation/MemberAuthController.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/presentation/MemberAuthController.java
@@ -33,19 +33,19 @@ public class MemberAuthController {
 	
 	// 이메일 인증 코드 발송
 	@PostMapping("/email/verify/send")
-	public ResponseEntity<EmailVerificationSendResponse> sendEmailVerification(@RequestBody EmailVerificationSendRequest request) {
+	public ResponseEntity<ApiResponse<EmailVerificationSendResponse>> sendEmailVerification(@RequestBody EmailVerificationSendRequest request) {
 		
-		emailVerificationService.sendVerificationEmail(request.toCommand());
+		EmailVerificationSendResponse response = emailVerificationService.sendVerificationEmail(request.toCommand());
 		
-		return ResponseEntity.ok(EmailVerificationSendResponse.success());
+		return ResponseEntity.ok(ApiResponse.ok(response));
 	}
 	
 	// 이메일 인증 코드 검증
 	@PostMapping("/email/verify/confirm")
-	public ResponseEntity<EmailVerificationConfirmResponse> confirmEmailVerification(@RequestBody EmailVerificationConfirmRequest request) {
+	public ResponseEntity<ApiResponse<EmailVerificationConfirmResponse>> confirmEmailVerification(@RequestBody EmailVerificationConfirmRequest request) {
 		
-		emailVerificationService.confirmVerification(request.toCommand());
+		EmailVerificationConfirmResponse response = emailVerificationService.confirmVerification(request.toCommand());
 		
-		return ResponseEntity.ok(EmailVerificationConfirmResponse.success());
+		return ResponseEntity.ok(ApiResponse.ok(response));
 	}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/auth/presentation/MemberAuthController.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/presentation/MemberAuthController.java
@@ -1,11 +1,13 @@
 package com.coc.modi.auth.presentation;
 
 import com.coc.modi.auth.application.MemberAuthService;
-import com.coc.modi.auth.application.dto.MemberLoginCommand;
+import com.coc.modi.auth.application.EmailVerificationService;
 import com.coc.modi.auth.application.dto.MemberLoginResponse;
-import com.coc.modi.auth.presentation.dto.MemberLoginRequest;
+import com.coc.modi.auth.presentation.dto.*;
 import com.coc.modi.common.ApiResponse;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,14 +18,34 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class MemberAuthController {
-
-    private final MemberAuthService memberAuthService;
-
-    @PostMapping("/login")
-    public ResponseEntity<ApiResponse<MemberLoginResponse>> login(@RequestBody MemberLoginRequest request){
-
-        MemberLoginResponse response = memberAuthService.login(request.toCommand());
-
-        return ResponseEntity.ok(ApiResponse.ok(response));
-    }
+	
+	private final MemberAuthService memberAuthService;
+	private final EmailVerificationService emailVerificationService;
+	
+	// 로그인
+	@PostMapping("/login")
+	public ResponseEntity<ApiResponse<MemberLoginResponse>> login(@RequestBody MemberLoginRequest request) {
+		
+		MemberLoginResponse response = memberAuthService.login(request.toCommand());
+		
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+	
+	// 이메일 인증 코드 발송
+	@PostMapping("/email/verify/send")
+	public ResponseEntity<EmailVerificationSendResponse> sendEmailVerification(@RequestBody EmailVerificationSendRequest request) {
+		
+		emailVerificationService.sendVerificationEmail(request.toCommand());
+		
+		return ResponseEntity.ok(EmailVerificationSendResponse.success());
+	}
+	
+	// 이메일 인증 코드 검증
+	@PostMapping("/email/verify/confirm")
+	public ResponseEntity<EmailVerificationConfirmResponse> confirmEmailVerification(@RequestBody EmailVerificationConfirmRequest request) {
+		
+		emailVerificationService.confirmVerification(request.toCommand());
+		
+		return ResponseEntity.ok(EmailVerificationConfirmResponse.success());
+	}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/auth/presentation/MemberAuthController.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/presentation/MemberAuthController.java
@@ -6,6 +6,7 @@ import com.coc.modi.auth.application.dto.MemberLoginResponse;
 import com.coc.modi.auth.presentation.dto.MemberLoginRequest;
 import com.coc.modi.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,15 +20,10 @@ public class MemberAuthController {
     private final MemberAuthService memberAuthService;
 
     @PostMapping("/login")
-    public ApiResponse<MemberLoginResponse> login(@RequestBody MemberLoginRequest request){
+    public ResponseEntity<ApiResponse<MemberLoginResponse>> login(@RequestBody MemberLoginRequest request){
 
-        MemberLoginCommand command = new MemberLoginCommand(
-                request.email(),
-                request.password()
-        );
+        MemberLoginResponse response = memberAuthService.login(request.toCommand());
 
-        MemberLoginResponse response = memberAuthService.login(command);
-
-        return ApiResponse.ok(response);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }

--- a/modi/member-service/src/main/java/com/coc/modi/auth/presentation/dto/EmailVerificationConfirmRequest.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/presentation/dto/EmailVerificationConfirmRequest.java
@@ -1,0 +1,13 @@
+package com.coc.modi.auth.presentation.dto;
+
+import com.coc.modi.auth.application.dto.ConfirmEmailVerificationCommand;
+
+public record EmailVerificationConfirmRequest(
+		String email,
+		String code
+) {
+	public ConfirmEmailVerificationCommand toCommand() {
+		
+		return new ConfirmEmailVerificationCommand(email, code);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/auth/presentation/dto/EmailVerificationConfirmResponse.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/presentation/dto/EmailVerificationConfirmResponse.java
@@ -1,0 +1,10 @@
+package com.coc.modi.auth.presentation.dto;
+
+public record EmailVerificationConfirmResponse(
+		boolean verified
+) {
+	public static EmailVerificationConfirmResponse success() {
+		
+		return new EmailVerificationConfirmResponse(true);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/auth/presentation/dto/EmailVerificationSendRequest.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/presentation/dto/EmailVerificationSendRequest.java
@@ -1,0 +1,12 @@
+package com.coc.modi.auth.presentation.dto;
+
+import com.coc.modi.auth.application.dto.SendEmailVerificationCommand;
+
+public record EmailVerificationSendRequest(
+		String email
+) {
+	public SendEmailVerificationCommand toCommand() {
+		
+		return new SendEmailVerificationCommand(email);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/auth/presentation/dto/EmailVerificationSendResponse.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/presentation/dto/EmailVerificationSendResponse.java
@@ -1,0 +1,10 @@
+package com.coc.modi.auth.presentation.dto;
+
+public record EmailVerificationSendResponse(
+		String result
+) {
+	public static EmailVerificationSendResponse success() {
+		
+		return new EmailVerificationSendResponse("OK");
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/auth/presentation/dto/MemberLoginInfo.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/presentation/dto/MemberLoginInfo.java
@@ -1,9 +1,0 @@
-package com.coc.modi.auth.presentation.dto;
-
-public record MemberLoginInfo(
-        Long id,
-        String email,
-        String name,
-        String role
-) {
-}

--- a/modi/member-service/src/main/java/com/coc/modi/auth/presentation/dto/MemberLoginRequest.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/presentation/dto/MemberLoginRequest.java
@@ -1,7 +1,16 @@
 package com.coc.modi.auth.presentation.dto;
 
+import com.coc.modi.auth.application.dto.MemberLoginCommand;
+
 public record MemberLoginRequest (
         String email,
         String password
 ) {
+    public MemberLoginCommand toCommand(){
+
+        return new MemberLoginCommand(
+                email,
+                password
+        );
+    }
 }

--- a/modi/member-service/src/main/java/com/coc/modi/auth/presentation/dto/MemberLoginRequest.java
+++ b/modi/member-service/src/main/java/com/coc/modi/auth/presentation/dto/MemberLoginRequest.java
@@ -2,15 +2,15 @@ package com.coc.modi.auth.presentation.dto;
 
 import com.coc.modi.auth.application.dto.MemberLoginCommand;
 
-public record MemberLoginRequest (
-        String email,
-        String password
+public record MemberLoginRequest(
+		String email,
+		String password
 ) {
-    public MemberLoginCommand toCommand(){
-
-        return new MemberLoginCommand(
-                email,
-                password
-        );
-    }
+	public MemberLoginCommand toCommand() {
+		
+		return new MemberLoginCommand(
+				email,
+				password
+		);
+	}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/MemberServiceApplication.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/MemberServiceApplication.java
@@ -5,28 +5,35 @@ import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @EnableJpaAuditing
+
 @SecurityScheme(
-        name = "BearerAuth",
-        type = SecuritySchemeType.HTTP,
-        bearerFormat = "JWT",
-        scheme = "bearer"
+		name = "BearerAuth",
+		type = SecuritySchemeType.HTTP,
+		bearerFormat = "JWT",
+		scheme = "bearer"
 )
+@EntityScan(basePackages = "com.coc.modi")
 @EnableFeignClients(basePackages = "com.coc.modi")
+@EnableJpaRepositories(basePackages = "com.coc.modi")
 @SpringBootApplication(scanBasePackages = "com.coc.modi")
 @OpenAPIDefinition(
-        info = @Info(title = "Member Service API", version = "1.0"),
-        security = @SecurityRequirement(name = "BearerAuth")
+		info = @Info(title = "Member Service API", version = "1.0"),
+		security = @SecurityRequirement(name = "BearerAuth")
 )
 public class MemberServiceApplication {
-
-    public static void main(String[] args) {
-        SpringApplication.run(MemberServiceApplication.class, args);
-    }
+	
+	public static void main(String[] args) {
+		
+		SpringApplication.run(MemberServiceApplication.class, args);
+	}
 }
 

--- a/modi/member-service/src/main/java/com/coc/modi/member/MemberServiceApplication.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/MemberServiceApplication.java
@@ -7,20 +7,18 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
-@SpringBootApplication(
-        scanBasePackages = {
-                "com.coc.modi"
-        }
-)
 @SecurityScheme(
         name = "BearerAuth",
         type = SecuritySchemeType.HTTP,
         bearerFormat = "JWT",
         scheme = "bearer"
 )
+@EnableFeignClients(basePackages = "com.coc.modi")
+@SpringBootApplication(scanBasePackages = "com.coc.modi")
 @OpenAPIDefinition(
         info = @Info(title = "Member Service API", version = "1.0"),
         security = @SecurityRequirement(name = "BearerAuth")

--- a/modi/member-service/src/main/java/com/coc/modi/member/MemberServiceApplication.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/MemberServiceApplication.java
@@ -9,8 +9,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication(scanBasePackages = {"com.coc.modi"})
 @EnableJpaAuditing
+@SpringBootApplication(
+        scanBasePackages = {
+                "com.coc.modi"
+        }
+)
 @SecurityScheme(
         name = "BearerAuth",
         type = SecuritySchemeType.HTTP,
@@ -27,3 +31,4 @@ public class MemberServiceApplication {
         SpringApplication.run(MemberServiceApplication.class, args);
     }
 }
+

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/MemberService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/MemberService.java
@@ -19,6 +19,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
+    // 회원가입
     @Transactional
     public MemberSignupResponse signup(CreateMemberCommand command){
 
@@ -47,10 +48,12 @@ public class MemberService {
         );
     }
 
+    // 내 정보 조회
     @Transactional(readOnly = true)
     public MemberProfileResponse getProfile(Authentication authentication){
 
         Long memberId = (Long) authentication.getPrincipal();
+
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("회원이 없습니다."));
 

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/MemberService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/MemberService.java
@@ -34,7 +34,7 @@ public class MemberService {
 		
 		if (memberRepository.existsByEmail(command.email())) {
 			
-			throw new IllegalArgumentException("Email already exists");
+			throw new IllegalArgumentException("이메일이 이미 존재합니다.");
 		}
 		
 		memberValidationService.validatePassword(command.password());

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/MemberService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/MemberService.java
@@ -6,6 +6,7 @@ import com.coc.modi.member.application.dto.MemberSignupResponse;
 import com.coc.modi.member.domain.Member;
 import com.coc.modi.member.domain.MemberRole;
 import com.coc.modi.member.domain.MemberRepository;
+import com.coc.modi.member.application.dto.UpdateMemberCommand;
 import com.coc.modi.member.infrastructure.client.AccountFeignClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -64,6 +65,49 @@ public class MemberService {
                 .orElseThrow(() -> new IllegalArgumentException("회원이 없습니다."));
 
         return MemberProfileResponse.from(member);
+    }
+
+    // 회원 정보 수정
+    @Transactional
+    public MemberProfileResponse updateProfile(Authentication authentication,
+                                               UpdateMemberCommand command) {
+
+        Long memberId = (Long) authentication.getPrincipal();
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 없습니다."));
+
+        if (command.name() != null && !command.name().isBlank()) {
+
+            member.changeName(command.name());
+        }
+
+        if (command.phone() != null && !command.phone().isBlank()) {
+
+            validatePhone(command.phone());
+            member.changePhone(command.phone());
+        }
+
+        if (command.newPassword() != null && !command.newPassword().isBlank()) {
+
+            validatePassword(command.newPassword());
+            String encodedPassword = passwordEncoder.encode(command.newPassword());
+            member.changePassword(encodedPassword);
+        }
+
+        return MemberProfileResponse.from(member);
+    }
+
+    // 회원 탈퇴
+    @Transactional
+    public void deleteMember(Authentication authentication) {
+
+        Long memberId = (Long) authentication.getPrincipal();
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 없습니다."));
+
+        member.withdraw();
     }
 
     // 비밀번호 유효성 검사

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/MemberService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/MemberService.java
@@ -40,12 +40,7 @@ public class MemberService {
 
         Member saved = memberRepository.save(member);
 
-        return new MemberSignupResponse(
-                saved.getEmail(),
-                saved.getName(),
-                saved.getPhone(),
-                saved.getCreatedAt()
-        );
+        return MemberSignupResponse.from(saved);
     }
 
     // 내 정보 조회
@@ -57,11 +52,6 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("회원이 없습니다."));
 
-        return new MemberProfileResponse(
-                member.getEmail(),
-                member.getName(),
-                member.getPhone(),
-                member.getCreatedAt()
-        );
+        return MemberProfileResponse.from(member);
     }
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/MemberService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/MemberService.java
@@ -25,10 +25,16 @@ public class MemberService {
     @Transactional
     public MemberSignupResponse signup(CreateMemberCommand command){
 
+        validateEmail(command.email());
+
         if(memberRepository.existsByEmail(command.email())){
 
             throw new IllegalArgumentException("Email already exists");
         }
+
+        validatePassword(command.password());
+
+        validatePhone(command.phone());
 
         String encodedPassword = passwordEncoder.encode(command.password());
 
@@ -58,5 +64,58 @@ public class MemberService {
                 .orElseThrow(() -> new IllegalArgumentException("회원이 없습니다."));
 
         return MemberProfileResponse.from(member);
+    }
+
+    // 비밀번호 유효성 검사
+    private void validatePassword(String password) {
+
+        if (password == null || password.isBlank()) {
+            throw new IllegalArgumentException("비밀번호를 입력해주세요.");
+        }
+
+        if (password.length() < 8 || password.length() > 20) {
+            throw new IllegalArgumentException("비밀번호는 8자 이상 20자 이하로 입력해주세요.");
+        }
+
+        if (!password.matches(".*[A-Za-z].*")) {
+            throw new IllegalArgumentException("비밀번호에는 영문자가 1개 이상 포함되어야 합니다.");
+        }
+
+        if(!password.matches(".*\\d.*")) {
+            throw new IllegalArgumentException("비밀번호에는 숫자가 1개 이상 포함되어야 합니다.");
+        }
+
+        if (!password.matches(".*[!@#$%^&*()_+\\-={}:\";'<>?,./].*")) {
+            throw new IllegalArgumentException("비밀번호에는 특수문자가 최소 1개 이상 포함되어야 합니다.");
+        }
+    }
+
+    // 이메일 유효성 검사
+    private void validateEmail(String email) {
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("이메일을 입력해주세요.");
+        }
+
+        String emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$";
+        if (!email.matches(emailRegex)) {
+            throw new IllegalArgumentException("이메일 형식이 올바르지 않습니다.");
+        }
+    }
+
+    // 전화번호 유효성 검사
+    private void validatePhone(String phone) {
+        if (phone == null || phone.isBlank()) {
+            throw new IllegalArgumentException("전화번호를 입력해주세요.");
+        }
+
+        String digits = phone.replaceAll("[^0-9]", "");
+
+        if (digits.length() < 9 || digits.length() > 11) {
+            throw new IllegalArgumentException("전화번호는 숫자 9~11자리여야 합니다.");
+        }
+
+        if (!digits.startsWith("0")) {
+            throw new IllegalArgumentException("전화번호 형식이 올바르지 않습니다.");
+        }
     }
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/MemberService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/MemberService.java
@@ -6,6 +6,7 @@ import com.coc.modi.member.application.dto.MemberSignupResponse;
 import com.coc.modi.member.domain.Member;
 import com.coc.modi.member.domain.MemberRole;
 import com.coc.modi.member.infrastructure.MemberRepository;
+import com.coc.modi.member.infrastructure.client.AccountFeignClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -18,6 +19,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AccountFeignClient accountFeignClient;
 
     // 회원가입
     @Transactional
@@ -39,6 +41,9 @@ public class MemberService {
         );
 
         Member saved = memberRepository.save(member);
+
+        // 회원 지갑 생성 요청
+        accountFeignClient.createWallet(saved.getId());
 
         return MemberSignupResponse.from(saved);
     }

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/MemberService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/MemberService.java
@@ -7,8 +7,11 @@ import com.coc.modi.member.domain.Member;
 import com.coc.modi.member.domain.MemberRole;
 import com.coc.modi.member.domain.MemberRepository;
 import com.coc.modi.member.application.dto.UpdateMemberCommand;
+import com.coc.modi.member.application.dto.UpdateMemberPasswordCommand;
 import com.coc.modi.member.infrastructure.client.AccountFeignClient;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,149 +20,122 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class MemberService {
-
-    private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
-    private final AccountFeignClient accountFeignClient;
-
-    // 회원가입
-    @Transactional
-    public MemberSignupResponse signup(CreateMemberCommand command){
-
-        validateEmail(command.email());
-
-        if(memberRepository.existsByEmail(command.email())){
-
-            throw new IllegalArgumentException("Email already exists");
-        }
-
-        validatePassword(command.password());
-
-        validatePhone(command.phone());
-
-        String encodedPassword = passwordEncoder.encode(command.password());
-
-        Member member = Member.create(
-                command.email(),
-                encodedPassword,
-                command.name(),
-                command.phone(),
-                MemberRole.USER
-        );
-
-        Member saved = memberRepository.save(member);
-
-        // 회원 지갑 생성 요청
-        accountFeignClient.createWallet(saved.getId());
-
-        return MemberSignupResponse.from(saved);
-    }
-
-    // 내 정보 조회
-    @Transactional(readOnly = true)
-    public MemberProfileResponse getProfile(Authentication authentication){
-
-        Long memberId = (Long) authentication.getPrincipal();
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("회원이 없습니다."));
-
-        return MemberProfileResponse.from(member);
-    }
-
-    // 회원 정보 수정
-    @Transactional
-    public MemberProfileResponse updateProfile(Authentication authentication,
-                                               UpdateMemberCommand command) {
-
-        Long memberId = (Long) authentication.getPrincipal();
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("회원이 없습니다."));
-
-        if (command.name() != null && !command.name().isBlank()) {
-
-            member.changeName(command.name());
-        }
-
-        if (command.phone() != null && !command.phone().isBlank()) {
-
-            validatePhone(command.phone());
-            member.changePhone(command.phone());
-        }
-
-        if (command.newPassword() != null && !command.newPassword().isBlank()) {
-
-            validatePassword(command.newPassword());
-            String encodedPassword = passwordEncoder.encode(command.newPassword());
-            member.changePassword(encodedPassword);
-        }
-
-        return MemberProfileResponse.from(member);
-    }
-
-    // 회원 탈퇴
-    @Transactional
-    public void deleteMember(Authentication authentication) {
-
-        Long memberId = (Long) authentication.getPrincipal();
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("회원이 없습니다."));
-
-        member.withdraw();
-    }
-
-    // 비밀번호 유효성 검사
-    private void validatePassword(String password) {
-
-        if (password == null || password.isBlank()) {
-            throw new IllegalArgumentException("비밀번호를 입력해주세요.");
-        }
-
-        if (password.length() < 8 || password.length() > 20) {
-            throw new IllegalArgumentException("비밀번호는 8자 이상 20자 이하로 입력해주세요.");
-        }
-
-        if (!password.matches(".*[A-Za-z].*")) {
-            throw new IllegalArgumentException("비밀번호에는 영문자가 1개 이상 포함되어야 합니다.");
-        }
-
-        if(!password.matches(".*\\d.*")) {
-            throw new IllegalArgumentException("비밀번호에는 숫자가 1개 이상 포함되어야 합니다.");
-        }
-
-        if (!password.matches(".*[!@#$%^&*()_+\\-={}:\";'<>?,./].*")) {
-            throw new IllegalArgumentException("비밀번호에는 특수문자가 최소 1개 이상 포함되어야 합니다.");
-        }
-    }
-
-    // 이메일 유효성 검사
-    private void validateEmail(String email) {
-        if (email == null || email.isBlank()) {
-            throw new IllegalArgumentException("이메일을 입력해주세요.");
-        }
-
-        String emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$";
-        if (!email.matches(emailRegex)) {
-            throw new IllegalArgumentException("이메일 형식이 올바르지 않습니다.");
-        }
-    }
-
-    // 전화번호 유효성 검사
-    private void validatePhone(String phone) {
-        if (phone == null || phone.isBlank()) {
-            throw new IllegalArgumentException("전화번호를 입력해주세요.");
-        }
-
-        String digits = phone.replaceAll("[^0-9]", "");
-
-        if (digits.length() < 9 || digits.length() > 11) {
-            throw new IllegalArgumentException("전화번호는 숫자 9~11자리여야 합니다.");
-        }
-
-        if (!digits.startsWith("0")) {
-            throw new IllegalArgumentException("전화번호 형식이 올바르지 않습니다.");
-        }
-    }
+	
+	private final MemberRepository memberRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final AccountFeignClient accountFeignClient;
+	private final MemberValidationService memberValidationService;
+	
+	// 회원가입
+	@Transactional
+	public MemberSignupResponse signup(CreateMemberCommand command) {
+		
+		memberValidationService.validateEmail(command.email());
+		
+		if (memberRepository.existsByEmail(command.email())) {
+			
+			throw new IllegalArgumentException("Email already exists");
+		}
+		
+		memberValidationService.validatePassword(command.password());
+		
+		memberValidationService.validatePhone(command.phone());
+		
+		String encodedPassword = passwordEncoder.encode(command.password());
+		
+		Member member = Member.create(
+				command.email(),
+				encodedPassword,
+				command.name(),
+				command.phone(),
+				MemberRole.USER
+		);
+		
+		Member saved = memberRepository.save(member);
+		
+		// 회원 지갑 생성 요청
+		accountFeignClient.createWallet(saved.getId());
+		
+		return MemberSignupResponse.from(saved);
+	}
+	
+	// 내 정보 조회
+	@Transactional(readOnly = true)
+	public MemberProfileResponse getProfile(Authentication authentication) {
+		
+		Long memberId = (Long)authentication.getPrincipal();
+		
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new IllegalArgumentException("회원이 없습니다."));
+		
+		return MemberProfileResponse.from(member);
+	}
+	
+	// 회원 정보 수정
+	@Transactional
+	public MemberProfileResponse updateProfile(Authentication authentication,
+											   UpdateMemberCommand command) {
+		
+		Long memberId = (Long)authentication.getPrincipal();
+		
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new IllegalArgumentException("회원이 없습니다."));
+		
+		if (command.name() != null && !command.name().isBlank()) {
+			
+			member.changeName(command.name());
+		}
+		
+		if (command.phone() != null && !command.phone().isBlank()) {
+			
+			memberValidationService.validatePhone(command.phone());
+			member.changePhone(command.phone());
+		}
+		
+		return MemberProfileResponse.from(member);
+	}
+	
+	// 비밀번호 수정
+	@Transactional
+	public void updatePassword(Authentication authentication,
+							   Long memberId,
+							   UpdateMemberPasswordCommand command) {
+		
+		Long authenticatedMemberId = (Long)authentication.getPrincipal();
+		
+		if (!authenticatedMemberId.equals(memberId)) {
+			
+			throw new IllegalArgumentException("본인만 비밀번호를 변경할 수 있습니다.");
+		}
+		
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new IllegalArgumentException("회원이 없습니다."));
+		
+		if (command.name() == null || command.name().isBlank()) {
+			
+			throw new IllegalArgumentException("이름을 입력해주세요.");
+		}
+		
+		if (!member.getName().equals(command.name())) {
+			
+			throw new IllegalArgumentException("이름이 일치하지 않습니다.");
+		}
+		
+		memberValidationService.validatePassword(command.password());
+		String encodedPassword = passwordEncoder.encode(command.password());
+		member.changePassword(encodedPassword);
+	}
+	
+	// 회원 탈퇴
+	@Transactional
+	public void deleteMember(Authentication authentication) {
+		
+		Long memberId = (Long)authentication.getPrincipal();
+		
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new IllegalArgumentException("회원이 없습니다."));
+		
+		member.withdraw();
+	}
+	
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/MemberService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/MemberService.java
@@ -5,7 +5,7 @@ import com.coc.modi.member.application.dto.MemberProfileResponse;
 import com.coc.modi.member.application.dto.MemberSignupResponse;
 import com.coc.modi.member.domain.Member;
 import com.coc.modi.member.domain.MemberRole;
-import com.coc.modi.member.infrastructure.MemberRepository;
+import com.coc.modi.member.domain.MemberRepository;
 import com.coc.modi.member.infrastructure.client.AccountFeignClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/MemberValidationService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/MemberValidationService.java
@@ -1,0 +1,73 @@
+package com.coc.modi.member.application;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberValidationService {
+	
+	// 비밀번호 유효성 검사
+	public void validatePassword(String password) {
+		
+		if (password == null || password.isBlank()) {
+			
+			throw new IllegalArgumentException("비밀번호를 입력해주세요.");
+		}
+		
+		if (password.length() < 8 || password.length() > 20) {
+			
+			throw new IllegalArgumentException("비밀번호는 8자 이상 20자 이하로 입력해주세요.");
+		}
+		
+		if (!password.matches(".*[A-Za-z].*")) {
+			
+			throw new IllegalArgumentException("비밀번호에는 영문자가 1개 이상 포함되어야 합니다.");
+		}
+		
+		if (!password.matches(".*\\d.*")) {
+			
+			throw new IllegalArgumentException("비밀번호에는 숫자가 1개 이상 포함되어야 합니다.");
+		}
+		
+		if (!password.matches(".*[!@#$%^&*()_+\\-={}:\";'<>?,./].*")) {
+			
+			throw new IllegalArgumentException("비밀번호에는 특수문자가 최소 1개 이상 포함되어야 합니다.");
+		}
+	}
+	
+	// 이메일 유효성 검사
+	public void validateEmail(String email) {
+		
+		if (email == null || email.isBlank()) {
+			
+			throw new IllegalArgumentException("이메일을 입력해주세요.");
+		}
+		
+		String emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$";
+		
+		if (!email.matches(emailRegex)) {
+			
+			throw new IllegalArgumentException("이메일 형식이 올바르지 않습니다.");
+		}
+	}
+	
+	// 휴대폰 번호 유효성 검사
+	public void validatePhone(String phone) {
+		
+		if (phone == null || phone.isBlank()) {
+			
+			throw new IllegalArgumentException("전화번호를 입력해주세요.");
+		}
+		
+		String digits = phone.replaceAll("[^0-9]", "");
+		
+		if (digits.length() < 9 || digits.length() > 11) {
+			
+			throw new IllegalArgumentException("전화번호는 숫자 9~11자리여야 합니다.");
+		}
+		
+		if (!digits.startsWith("0")) {
+			
+			throw new IllegalArgumentException("전화번호 형식이 올바르지 않습니다.");
+		}
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/dto/CreateMemberCommand.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/dto/CreateMemberCommand.java
@@ -1,9 +1,9 @@
 package com.coc.modi.member.application.dto;
 
-public record CreateMemberCommand (
-        String email,
-        String password,
-        String name,
-        String phone
+public record CreateMemberCommand(
+		String email,
+		String password,
+		String name,
+		String phone
 ) {
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/dto/MemberProfileResponse.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/dto/MemberProfileResponse.java
@@ -2,21 +2,17 @@ package com.coc.modi.member.application.dto;
 
 import com.coc.modi.member.domain.Member;
 
-import java.time.LocalDateTime;
-
 public record MemberProfileResponse(
-        String email,
-        String name,
-        String phone,
-        LocalDateTime createdAt
+		Long id,
+		String name,
+		String phone
 ) {
-    public static MemberProfileResponse from(Member member) {
-
-        return new MemberProfileResponse(
-                member.getEmail(),
-                member.getName(),
-                member.getPhone(),
-                member.getCreatedAt()
-        );
-    }
+	public static MemberProfileResponse from(Member member) {
+		
+		return new MemberProfileResponse(
+				member.getId(),
+				member.getName(),
+				member.getPhone()
+		);
+	}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/dto/MemberProfileResponse.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/dto/MemberProfileResponse.java
@@ -1,5 +1,7 @@
 package com.coc.modi.member.application.dto;
 
+import com.coc.modi.member.domain.Member;
+
 import java.time.LocalDateTime;
 
 public record MemberProfileResponse(
@@ -8,5 +10,13 @@ public record MemberProfileResponse(
         String phone,
         LocalDateTime createdAt
 ) {
+    public static MemberProfileResponse from(Member member) {
 
+        return new MemberProfileResponse(
+                member.getEmail(),
+                member.getName(),
+                member.getPhone(),
+                member.getCreatedAt()
+        );
+    }
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/dto/MemberSignupResponse.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/dto/MemberSignupResponse.java
@@ -5,18 +5,18 @@ import com.coc.modi.member.domain.Member;
 import java.time.LocalDateTime;
 
 public record MemberSignupResponse(
-        String email,
-        String name,
-        String phone,
-        LocalDateTime createdAt
+		String email,
+		String name,
+		String phone,
+		LocalDateTime createdAt
 ) {
-    public static MemberSignupResponse from(Member member) {
-
-        return new MemberSignupResponse(
-                member.getEmail(),
-                member.getName(),
-                member.getPhone(),
-                member.getCreatedAt()
-        );
-    }
+	public static MemberSignupResponse from(Member member) {
+		
+		return new MemberSignupResponse(
+				member.getEmail(),
+				member.getName(),
+				member.getPhone(),
+				member.getCreatedAt()
+		);
+	}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/dto/MemberSignupResponse.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/dto/MemberSignupResponse.java
@@ -1,5 +1,7 @@
 package com.coc.modi.member.application.dto;
 
+import com.coc.modi.member.domain.Member;
+
 import java.time.LocalDateTime;
 
 public record MemberSignupResponse(
@@ -8,4 +10,13 @@ public record MemberSignupResponse(
         String phone,
         LocalDateTime createdAt
 ) {
+    public static MemberSignupResponse from(Member member) {
+
+        return new MemberSignupResponse(
+                member.getEmail(),
+                member.getName(),
+                member.getPhone(),
+                member.getCreatedAt()
+        );
+    }
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/dto/UpdateMemberCommand.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/dto/UpdateMemberCommand.java
@@ -1,0 +1,8 @@
+package com.coc.modi.member.application.dto;
+
+public record UpdateMemberCommand(
+        String name,
+        String phone,
+        String newPassword
+) {
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/dto/UpdateMemberCommand.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/dto/UpdateMemberCommand.java
@@ -1,8 +1,7 @@
 package com.coc.modi.member.application.dto;
 
 public record UpdateMemberCommand(
-        String name,
-        String phone,
-        String newPassword
+		String name,
+		String phone
 ) {
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/application/dto/UpdateMemberPasswordCommand.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/application/dto/UpdateMemberPasswordCommand.java
@@ -1,0 +1,7 @@
+package com.coc.modi.member.application.dto;
+
+public record UpdateMemberPasswordCommand(
+		String name,
+		String password
+) {
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/domain/Address.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/domain/Address.java
@@ -1,6 +1,7 @@
 package com.coc.modi.member.domain;
 
 import com.coc.modi.common.BaseEntity;
+
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -8,38 +9,38 @@ import lombok.Getter;
 @Entity
 @Table(name = "address", schema = "public")
 public class Address extends BaseEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @ManyToOne
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
-
-    @Column(name = "address_label", length = 50)
-    private String addressLabel;
-
-    @Column(name = "recipient_name", nullable = false, length = 50)
-    private String recipientName;
-
-    @Column(name = "recipient_phone", nullable = false, length = 20)
-    private String recipientPhone;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "type", nullable = false, length = 20)
-    private AddressType type;
-
-    @Column(name = "postcode", nullable = false, length = 10)
-    private String postcode;
-
-    @Column(name = "road_address", nullable = false, length = 255)
-    private String roadAddress;
-
-    @Column(name = "detail_address", nullable = false, length = 255)
-    private String detailAddress;
-
-    @Column(name = "is_default", nullable = false)
-    private boolean isDefault;
-
+	
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	@ManyToOne
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+	
+	@Column(name = "address_label", length = 50)
+	private String addressLabel;
+	
+	@Column(name = "recipient_name", nullable = false, length = 50)
+	private String recipientName;
+	
+	@Column(name = "recipient_phone", nullable = false, length = 20)
+	private String recipientPhone;
+	
+	@Enumerated(EnumType.STRING)
+	@Column(name = "type", nullable = false, length = 20)
+	private AddressType type;
+	
+	@Column(name = "postcode", nullable = false, length = 10)
+	private String postcode;
+	
+	@Column(name = "road_address", nullable = false, length = 255)
+	private String roadAddress;
+	
+	@Column(name = "detail_address", nullable = false, length = 255)
+	private String detailAddress;
+	
+	@Column(name = "is_default", nullable = false)
+	private boolean isDefault;
+	
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/domain/Member.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/domain/Member.java
@@ -62,4 +62,24 @@ public class Member extends BaseEntity {
                                 MemberRole role) {
         return new Member(email, password, name, phone, role);
     }
+
+    public void changeName(String name) {
+
+        this.name = name;
+    }
+
+    public void changePhone(String phone) {
+
+        this.phone = phone;
+    }
+
+    public void changePassword(String password) {
+
+        this.password = password;
+    }
+
+    public void withdraw() {
+
+        this.status = MemberStatus.WITHDRAWN;
+    }
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/domain/Member.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/domain/Member.java
@@ -1,6 +1,7 @@
 package com.coc.modi.member.domain;
 
 import com.coc.modi.common.BaseEntity;
+
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,75 +12,77 @@ import lombok.NoArgsConstructor;
 @Table(name = "member", schema = "public")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @Column(nullable = false, length = 255, unique = true)
-    private String email;
-
-    @Column(nullable = false, length = 100)
-    private String name;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
-    private MemberStatus status;
-
-    @Column(nullable = false, length = 255)
-    private String password;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
-    private MemberRole role;
-
-    @Column(nullable = false, length = 20)
-    private String phone;
-
-    @Column(length = 20)
-    private String provider;
-
-    @Column(length = 100)
-    private String providerId;
-
-    private Member(String email,
-                   String password,
-                   String name,
-                   String phone,
-                   MemberRole role) {
-        this.email = email;
-        this.password = password;
-        this.name = name;
-        this.phone = phone;
-        this.role = role;
-        this.status = MemberStatus.ACTIVE;
-    }
-
-    public static Member create(String email,
-                                String password,
-                                String name,
-                                String phone,
-                                MemberRole role) {
-        return new Member(email, password, name, phone, role);
-    }
-
-    public void changeName(String name) {
-
-        this.name = name;
-    }
-
-    public void changePhone(String phone) {
-
-        this.phone = phone;
-    }
-
-    public void changePassword(String password) {
-
-        this.password = password;
-    }
-
-    public void withdraw() {
-
-        this.status = MemberStatus.WITHDRAWN;
-    }
+	
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	@Column(nullable = false, length = 255, unique = true)
+	private String email;
+	
+	@Column(nullable = false, length = 100)
+	private String name;
+	
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private MemberStatus status;
+	
+	@Column(nullable = false, length = 255)
+	private String password;
+	
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private MemberRole role;
+	
+	@Column(nullable = false, length = 20)
+	private String phone;
+	
+	@Column(length = 20)
+	private String provider;
+	
+	@Column(length = 100)
+	private String providerId;
+	
+	private Member(String email,
+				   String password,
+				   String name,
+				   String phone,
+				   MemberRole role) {
+		
+		this.email = email;
+		this.password = password;
+		this.name = name;
+		this.phone = phone;
+		this.role = role;
+		this.status = MemberStatus.ACTIVE;
+	}
+	
+	public static Member create(String email,
+								String password,
+								String name,
+								String phone,
+								MemberRole role) {
+		
+		return new Member(email, password, name, phone, role);
+	}
+	
+	public void changeName(String name) {
+		
+		this.name = name;
+	}
+	
+	public void changePhone(String phone) {
+		
+		this.phone = phone;
+	}
+	
+	public void changePassword(String password) {
+		
+		this.password = password;
+	}
+	
+	public void withdraw() {
+		
+		this.status = MemberStatus.WITHDRAWN;
+	}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/domain/MemberRepository.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/domain/MemberRepository.java
@@ -1,0 +1,14 @@
+package com.coc.modi.member.domain;
+
+import java.util.Optional;
+
+public interface MemberRepository {
+
+    boolean existsByEmail(String email);
+
+    Optional<Member> findByEmail(String email);
+
+    Member save(Member member);
+
+    Optional<Member> findById(Long memberId);
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/domain/MemberRepository.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/domain/MemberRepository.java
@@ -3,12 +3,12 @@ package com.coc.modi.member.domain;
 import java.util.Optional;
 
 public interface MemberRepository {
-
-    boolean existsByEmail(String email);
-
-    Optional<Member> findByEmail(String email);
-
-    Member save(Member member);
-
-    Optional<Member> findById(Long memberId);
+	
+	boolean existsByEmail(String email);
+	
+	Optional<Member> findByEmail(String email);
+	
+	Member save(Member member);
+	
+	Optional<Member> findById(Long memberId);
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/domain/MemberRole.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/domain/MemberRole.java
@@ -1,6 +1,6 @@
 package com.coc.modi.member.domain;
 
 public enum MemberRole {
-    USER,
-    SELLER
+	USER,
+	SELLER
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/domain/MemberStatus.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/domain/MemberStatus.java
@@ -1,7 +1,7 @@
 package com.coc.modi.member.domain;
 
 public enum MemberStatus {
-    ACTIVE,
-    INACTIVE,
-    WITHDRAWN
+	ACTIVE,
+	INACTIVE,
+	WITHDRAWN
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/infrastructure/MemberJpaRepository.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/infrastructure/MemberJpaRepository.java
@@ -1,13 +1,14 @@
 package com.coc.modi.member.infrastructure;
 
 import com.coc.modi.member.domain.Member;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface MemberJpaRepository extends JpaRepository<Member, Long> {
-
-    boolean existsByEmail(String email);
-
-    Optional<Member> findByEmail(String email);
+	
+	boolean existsByEmail(String email);
+	
+	Optional<Member> findByEmail(String email);
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/infrastructure/MemberRepositoryAdapter.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/infrastructure/MemberRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package com.coc.modi.member.infrastructure;
 
 import com.coc.modi.member.domain.Member;
+import com.coc.modi.member.domain.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -8,27 +9,27 @@ import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
-public class MemberRepository {
+public class MemberRepositoryAdapter implements MemberRepository {
 
     private final MemberJpaRepository memberJpaRepository;
 
+    @Override
     public boolean existsByEmail(String email) {
-
         return memberJpaRepository.existsByEmail(email);
     }
 
+    @Override
     public Optional<Member> findByEmail(String email) {
-
         return memberJpaRepository.findByEmail(email);
     }
 
+    @Override
     public Member save(Member member) {
-
         return memberJpaRepository.save(member);
     }
 
+    @Override
     public Optional<Member> findById(Long memberId) {
-
         return memberJpaRepository.findById(memberId);
     }
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/infrastructure/MemberRepositoryAdapter.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/infrastructure/MemberRepositoryAdapter.java
@@ -2,7 +2,9 @@ package com.coc.modi.member.infrastructure;
 
 import com.coc.modi.member.domain.Member;
 import com.coc.modi.member.domain.MemberRepository;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,26 +12,30 @@ import java.util.Optional;
 @Repository
 @RequiredArgsConstructor
 public class MemberRepositoryAdapter implements MemberRepository {
-
-    private final MemberJpaRepository memberJpaRepository;
-
-    @Override
-    public boolean existsByEmail(String email) {
-        return memberJpaRepository.existsByEmail(email);
-    }
-
-    @Override
-    public Optional<Member> findByEmail(String email) {
-        return memberJpaRepository.findByEmail(email);
-    }
-
-    @Override
-    public Member save(Member member) {
-        return memberJpaRepository.save(member);
-    }
-
-    @Override
-    public Optional<Member> findById(Long memberId) {
-        return memberJpaRepository.findById(memberId);
-    }
+	
+	private final MemberJpaRepository memberJpaRepository;
+	
+	@Override
+	public boolean existsByEmail(String email) {
+		
+		return memberJpaRepository.existsByEmail(email);
+	}
+	
+	@Override
+	public Optional<Member> findByEmail(String email) {
+		
+		return memberJpaRepository.findByEmail(email);
+	}
+	
+	@Override
+	public Member save(Member member) {
+		
+		return memberJpaRepository.save(member);
+	}
+	
+	@Override
+	public Optional<Member> findById(Long memberId) {
+		
+		return memberJpaRepository.findById(memberId);
+	}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/infrastructure/client/AccountFeignClient.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/infrastructure/client/AccountFeignClient.java
@@ -1,0 +1,16 @@
+package com.coc.modi.member.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(
+        name = "account-service",
+        url = "${account-service.url}",
+        path = "/internal/wallets"
+)
+public interface AccountFeignClient {
+
+    @PostMapping("/{memberId}")
+    void createWallet(@PathVariable Long memberId);
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/infrastructure/client/AccountFeignClient.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/infrastructure/client/AccountFeignClient.java
@@ -5,12 +5,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
 @FeignClient(
-        name = "account-service",
-        url = "${account-service.url}",
-        path = "/internal/wallets"
+		name = "account-service",
+		url = "${account-service.url}",
+		path = "/internal/wallets"
 )
 public interface AccountFeignClient {
-
-    @PostMapping("/{memberId}")
-    void createWallet(@PathVariable Long memberId);
+	
+	@PostMapping("/{memberId}")
+	void createWallet(@PathVariable Long memberId);
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/presentation/MemberController.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/presentation/MemberController.java
@@ -5,8 +5,11 @@ import com.coc.modi.member.application.dto.MemberProfileResponse;
 import com.coc.modi.member.application.dto.MemberSignupResponse;
 import com.coc.modi.member.presentation.dto.MemberSignupRequest;
 import com.coc.modi.member.presentation.dto.MemberUpdateRequest;
+import com.coc.modi.member.presentation.dto.MemberPasswordUpdateRequest;
 import com.coc.modi.common.ApiResponse;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -15,43 +18,54 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
 public class MemberController {
-
-    private final MemberService memberService;
-
-    // 회원가입
-    @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<MemberSignupResponse>> signup(@RequestBody MemberSignupRequest request){
-
-        MemberSignupResponse response = memberService.signup(request.toCommand());
-
-        return ResponseEntity.ok(ApiResponse.ok(response));
-    }
-
-    // 내 정보 조회
-    @GetMapping("/profile")
-    public ResponseEntity<ApiResponse<MemberProfileResponse>> getProfile(Authentication authentication){
-
-        MemberProfileResponse response = memberService.getProfile(authentication);
-
-        return ResponseEntity.ok(ApiResponse.ok(response));
-    }
-
-    // 내 정보 수정
-    @PutMapping("/profile")
-    public ResponseEntity<ApiResponse<MemberProfileResponse>> updateProfile(Authentication authentication,
-                                                                           @RequestBody MemberUpdateRequest request) {
-
-        MemberProfileResponse response = memberService.updateProfile(authentication, request.toCommand());
-
-        return ResponseEntity.ok(ApiResponse.ok(response));
-    }
-
-    // 회원 탈퇴
-    @DeleteMapping
-    public ResponseEntity<ApiResponse<?>> deleteMember(Authentication authentication) {
-
-        memberService.deleteMember(authentication);
-
-        return ResponseEntity.ok(ApiResponse.ok());
-    }
+	
+	private final MemberService memberService;
+	
+	// 회원가입
+	@PostMapping("/signup")
+	public ResponseEntity<ApiResponse<MemberSignupResponse>> signup(@RequestBody MemberSignupRequest request) {
+		
+		MemberSignupResponse response = memberService.signup(request.toCommand());
+		
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+	
+	// 내 정보 조회
+	@GetMapping("/profile")
+	public ResponseEntity<ApiResponse<MemberProfileResponse>> getProfile(Authentication authentication) {
+		
+		MemberProfileResponse response = memberService.getProfile(authentication);
+		
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+	
+	// 내 정보 수정
+	@PutMapping("/profile")
+	public ResponseEntity<ApiResponse<MemberProfileResponse>> updateProfile(Authentication authentication,
+																			@RequestBody MemberUpdateRequest request) {
+		
+		MemberProfileResponse response = memberService.updateProfile(authentication, request.toCommand());
+		
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+	
+	// 비밀번호 수정
+	@PatchMapping("/{memberId}/passwords")
+	public ResponseEntity<ApiResponse<?>> updatePassword(Authentication authentication,
+														 @PathVariable Long memberId,
+														 @RequestBody MemberPasswordUpdateRequest request) {
+		
+		memberService.updatePassword(authentication, memberId, request.toCommand());
+		
+		return ResponseEntity.ok(ApiResponse.ok());
+	}
+	
+	// 회원 탈퇴
+	@DeleteMapping
+	public ResponseEntity<ApiResponse<?>> deleteMember(Authentication authentication) {
+		
+		memberService.deleteMember(authentication);
+		
+		return ResponseEntity.ok(ApiResponse.ok());
+	}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/presentation/MemberController.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/presentation/MemberController.java
@@ -1,10 +1,10 @@
 package com.coc.modi.member.presentation;
 
 import com.coc.modi.member.application.MemberService;
-import com.coc.modi.member.application.dto.CreateMemberCommand;
 import com.coc.modi.member.application.dto.MemberProfileResponse;
 import com.coc.modi.member.application.dto.MemberSignupResponse;
 import com.coc.modi.member.presentation.dto.MemberSignupRequest;
+import com.coc.modi.member.presentation.dto.MemberUpdateRequest;
 import com.coc.modi.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -36,4 +36,22 @@ public class MemberController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
+    // 내 정보 수정
+    @PutMapping("/profile")
+    public ResponseEntity<ApiResponse<MemberProfileResponse>> updateProfile(Authentication authentication,
+                                                                           @RequestBody MemberUpdateRequest request) {
+
+        MemberProfileResponse response = memberService.updateProfile(authentication, request.toCommand());
+
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    // 회원 탈퇴
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<?>> deleteMember(Authentication authentication) {
+
+        memberService.deleteMember(authentication);
+
+        return ResponseEntity.ok(ApiResponse.ok());
+    }
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/presentation/MemberController.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/presentation/MemberController.java
@@ -19,7 +19,7 @@ public class MemberController {
     private final MemberService memberService;
 
     // 회원가입
-    @PostMapping
+    @PostMapping("/signup")
     public ResponseEntity<ApiResponse<MemberSignupResponse>> signup(@RequestBody MemberSignupRequest request){
 
         MemberSignupResponse response = memberService.signup(request.toCommand());

--- a/modi/member-service/src/main/java/com/coc/modi/member/presentation/MemberController.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/presentation/MemberController.java
@@ -7,6 +7,7 @@ import com.coc.modi.member.application.dto.MemberSignupResponse;
 import com.coc.modi.member.presentation.dto.MemberSignupRequest;
 import com.coc.modi.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,27 +18,22 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    // 회원가입
     @PostMapping
-    public ApiResponse<MemberSignupResponse> signup(@RequestBody MemberSignupRequest request){
+    public ResponseEntity<ApiResponse<MemberSignupResponse>> signup(@RequestBody MemberSignupRequest request){
 
-        CreateMemberCommand command = new CreateMemberCommand(
-                request.email(),
-                request.password(),
-                request.name(),
-                request.phone()
-        );
+        MemberSignupResponse response = memberService.signup(request.toCommand());
 
-        MemberSignupResponse response = memberService.signup(command);
-
-        return ApiResponse.ok(response);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
+    // 내 정보 조회
     @GetMapping("/profile")
-    public ApiResponse<MemberProfileResponse> getProfile(Authentication authentication){
+    public ResponseEntity<ApiResponse<MemberProfileResponse>> getProfile(Authentication authentication){
 
         MemberProfileResponse response = memberService.getProfile(authentication);
 
-        return ApiResponse.ok(response);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/presentation/dto/MemberPasswordUpdateRequest.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/presentation/dto/MemberPasswordUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.coc.modi.member.presentation.dto;
+
+import com.coc.modi.member.application.dto.UpdateMemberPasswordCommand;
+
+public record MemberPasswordUpdateRequest(
+		String name,
+		String password
+) {
+	public UpdateMemberPasswordCommand toCommand() {
+		
+		return new UpdateMemberPasswordCommand(
+				name,
+				password
+		);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/presentation/dto/MemberSignupRequest.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/presentation/dto/MemberSignupRequest.java
@@ -9,6 +9,7 @@ public record MemberSignupRequest (
         String phone
 ) {
     public CreateMemberCommand toCommand(){
+
         return new CreateMemberCommand(
                 email,
                 password,

--- a/modi/member-service/src/main/java/com/coc/modi/member/presentation/dto/MemberSignupRequest.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/presentation/dto/MemberSignupRequest.java
@@ -2,19 +2,19 @@ package com.coc.modi.member.presentation.dto;
 
 import com.coc.modi.member.application.dto.CreateMemberCommand;
 
-public record MemberSignupRequest (
-        String email,
-        String password,
-        String name,
-        String phone
+public record MemberSignupRequest(
+		String email,
+		String password,
+		String name,
+		String phone
 ) {
-    public CreateMemberCommand toCommand(){
-
-        return new CreateMemberCommand(
-                email,
-                password,
-                name,
-                phone
-        );
-    }
+	public CreateMemberCommand toCommand() {
+		
+		return new CreateMemberCommand(
+				email,
+				password,
+				name,
+				phone
+		);
+	}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/presentation/dto/MemberUpdateRequest.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/presentation/dto/MemberUpdateRequest.java
@@ -3,16 +3,14 @@ package com.coc.modi.member.presentation.dto;
 import com.coc.modi.member.application.dto.UpdateMemberCommand;
 
 public record MemberUpdateRequest(
-        String name,
-        String phone,
-        String newPassword
+		String name,
+		String phone
 ) {
-    public UpdateMemberCommand toCommand() {
-
-        return new UpdateMemberCommand(
-                name,
-                phone,
-                newPassword
-        );
-    }
+	public UpdateMemberCommand toCommand() {
+		
+		return new UpdateMemberCommand(
+				name,
+				phone
+		);
+	}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/presentation/dto/MemberUpdateRequest.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/presentation/dto/MemberUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.coc.modi.member.presentation.dto;
+
+import com.coc.modi.member.application.dto.UpdateMemberCommand;
+
+public record MemberUpdateRequest(
+        String name,
+        String phone,
+        String newPassword
+) {
+    public UpdateMemberCommand toCommand() {
+
+        return new UpdateMemberCommand(
+                name,
+                phone,
+                newPassword
+        );
+    }
+}


### PR DESCRIPTION
## 개요
member-service 회원 정보 수정, 탈퇴 및 회원가입시 이메일 인증 기능 구현

## 변경 사항
### account-service
 - 비밀번호 변경을 별도 엔드포인트로 분리하고, 프로필 수정은 이름/전화번호만 처리하도록 정리
 - 이메일 인증 코드 발송/검증 엔드포인트를 추가하고, 코드 저장을 위한 엔티티·레포지토리/서비스 계층 구현
 - Gmail SMTP 기반 메일 발송(환경변수 기반)과 JavaMailSender 연동을 추가해 실제 인증 메일 전송
 - 비밀번호/이메일/전화번호 검증 로직을 MemberValidationService로 추출해 공통화

## 관련 이슈


## 테스트
- [ o ] 로컬 빌드 성공
- [ o ] API 테스트 완료

## 리뷰 요청 사항
