### PR TITLE
feat: 상품 조회 날짜 필터링 및 내부 API 연동 위한 Feign Client 추가

### DIFF
--- a/modi/product-service/build.gradle
+++ b/modi/product-service/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
     implementation project(':common')
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'org.postgresql:postgresql'
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'

--- a/modi/product-service/src/main/java/com/coc/modi/product/ProductServiceApplication.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/ProductServiceApplication.java
@@ -2,8 +2,12 @@ package com.coc.modi.product;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication
+@EnableJpaAuditing
+@EnableFeignClients(basePackages = "com.coc.modi")
+@SpringBootApplication(scanBasePackages = "com.coc.modi")
 public class ProductServiceApplication {
 
     public static void main(String[] args) {

--- a/modi/product-service/src/main/java/com/coc/modi/product/application/ProductService.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/application/ProductService.java
@@ -2,17 +2,27 @@ package com.coc.modi.product.application;
 
 import com.coc.modi.product.application.dto.*;
 import com.coc.modi.product.domain.*;
+import com.coc.modi.product.infrastructure.client.RentalFeignClient;
+import com.coc.modi.product.infrastructure.client.SellerFeignClient;
+import com.coc.modi.product.presentation.dto.RentalRequest;
 import com.coc.modi.product.search.ProductDocument;
 import com.coc.modi.product.search.ProductIndexService;
 import com.coc.modi.product.search.ProductSearchQueryRepository;
 import com.coc.modi.product.search.ProductSearchRepository;
+import com.coc.modi.product.search.ProductSortType;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -23,27 +33,86 @@ public class ProductService {
     private final ProductSearchRepository searchRepository;
     private final ProductSearchQueryRepository searchQueryRepository;
     private final ProductIndexService indexService;
-
-    // 3-1. 상품 목록 조회 기본 조회만
-    @Transactional(readOnly = true)
-    public List<ProductListResponse> getProducts(Pageable pageable) {
-
-        Page<ProductDocument> docs = searchRepository.findByStatus(ProductStatus.ACTIVE.name(), pageable);
-
-        return docs.map(ProductListResponse::from).getContent();
-    }
+	private final SellerFeignClient sellerFeignClient;
+	private final RentalFeignClient rentalFeignClient;
 
     // 3-1. 상품 목록 조회 검색 기능
     @Transactional(readOnly = true)
-    public List<ProductListResponse> searchProducts(ProductSearchCondition condition, Pageable pageable) {
-
-        if (condition == null || condition.isEmpty()) {
-            return getProducts(pageable);
-        }
-
-        Page<ProductDocument> docs = searchQueryRepository.search(condition, pageable);
-
-        return docs.map(ProductListResponse::from).getContent();
+    public ProductScrollResponse searchProducts(ProductSearchCondition condition, String cursor, int size, ProductSortType sortType) {
+		
+		ProductSortType effectiveSortType = sortType != null ? sortType : condition.effectiveSortType();
+		
+		List<ProductListResponse> items = new ArrayList<>();
+		String currentCursor = cursor;
+		boolean hasMoreFromEs = true;
+		int safetyLimit = 5;
+		
+		List<ProductDocument> lastDocsBatch = List.of();
+		
+		while (items.size() < size && hasMoreFromEs && safetyLimit-- > 0) {
+			
+			// ES에서 1차 검색
+			List<ProductDocument> docs = searchQueryRepository.search(condition, currentCursor, size, effectiveSortType);
+			
+			if (docs.isEmpty()) {
+				hasMoreFromEs = false;
+				break;
+			}
+			
+			lastDocsBatch = docs;
+			
+			List<ProductDocument> availableDocs = docs;
+			
+			// 렌탈 기간 필터가 있는 경우(대여 불가 상품 제거)
+			if (condition.hasRentalPeriod()) {
+				List<Long> productIds = docs.stream()
+						.map(ProductDocument::getId)
+						.toList();
+				
+				if(!productIds.isEmpty()) {
+					RentalRequest request = new RentalRequest(condition.startDate(), condition.endDate(), productIds);
+					
+					RentalResponse rentalResponse = rentalFeignClient.unavailableProducts(request);
+					
+					Set<Long> unavailableIds = new HashSet<>(
+							Optional.ofNullable(rentalResponse)
+									.map(RentalResponse::unavailableProductIds)
+									.orElseGet(List::of)
+					);
+					
+					availableDocs = docs.stream()
+							.filter(doc -> !unavailableIds.contains(doc.getId())).toList();
+				}
+			}
+			
+			// 대여 가능한 리스트만 item에 추가
+			items.addAll(availableDocs.stream()
+					.map(ProductListResponse::from)
+					.toList());
+			
+			// cursor 갱신
+			currentCursor = buildNextCursor(docs, effectiveSortType);
+			hasMoreFromEs = docs.size() == size && currentCursor != null;
+		}
+		
+		// items가 빈 경우
+		if (items.isEmpty()) {
+			return new ProductScrollResponse(List.of(), null, false);
+		}
+		
+		// size보다 많이 쌓인 경우 잘라주기
+		if (items.size() > size) {
+			items = items.subList(0, size);
+		}
+		
+		// 결과 반환
+		String nextCursor = (hasMoreFromEs && !lastDocsBatch.isEmpty())
+				? currentCursor
+				: null;
+		
+		boolean hasNext = hasMoreFromEs;
+		
+		return new ProductScrollResponse(items, nextCursor, hasNext);
     }
 
     // 3-2. 상품 상세 조회
@@ -58,8 +127,10 @@ public class ProductService {
 
     // 3-4. 상품 등록
     @Transactional
-    public ProductResponse createProduct(Long sellerId, ProductCommand command) {
-
+    public ProductResponse createProduct(Long memberId, ProductCommand command) {
+		
+		Long sellerId = sellerFeignClient.findSellerById(memberId).sellerId();
+		
         Product product = Product.create(
                 sellerId,
                 command.name(),
@@ -81,10 +152,16 @@ public class ProductService {
 
     // 3-5. 상품 수정
     @Transactional
-    public ProductResponse updateProduct(Long productId, ProductUpdateCommand command) {
+    public ProductResponse updateProduct(Long memberId, Long productId, ProductUpdateCommand command) {
+		
+		Long sellerId = sellerFeignClient.findSellerById(memberId).sellerId();
 
         Product product = repository.findById(productId)
                 .orElseThrow(() -> new IllegalArgumentException("PRODUCT NOT FOUND: " + productId));
+		
+		if (!sellerId.equals(product.getSellerId())) {
+			throw new IllegalArgumentException("해당 상품의 수정 권한이 없습니다.");
+		}
 
         product.update(command.name(),
                 command.description(),
@@ -107,16 +184,16 @@ public class ProductService {
 
     // 3-6. 상품 숨김
     @Transactional
-    public void disableProduct(Long productId) {
+    public void disableProduct(Long memberId, Long productId) {
 
-        changeStatus(productId, ProductStatus.INACTIVE);
+        changeStatus(memberId, productId, ProductStatus.INACTIVE);
     }
 
     // 3-7. 상품 삭제
     @Transactional
-    public void deleteProduct(Long productId) {
+    public void deleteProduct(Long memberId, Long productId) {
 
-        changeStatus(productId, ProductStatus.DELETE);
+        changeStatus(memberId, productId, ProductStatus.DELETE);
     }
 
     // 내부 api
@@ -128,6 +205,50 @@ public class ProductService {
                 .map(ProductBulkResponse::from)
                 .toList();
     }
+	
+	// 다음 커서
+	private String buildNextCursor(List<ProductDocument> docs, ProductSortType sortType) {
+		return switch (sortType) {
+			case LATEST, OLDEST -> {
+				// 뒤에서부터 createdAt 이 있는 문서를 찾음
+				ProductDocument target = null;
+				for (int i = docs.size() - 1; i >= 0; i--) {
+					if (docs.get(i).getCreatedAt() != null) {
+						target = docs.get(i);
+						break;
+					}
+				}
+				
+				if (target == null) {
+					// createdAt 이 하나도 없는 배치면 커서를 만들 수 없음
+					yield null;
+				}
+				
+				String rawCursor = target.getCreatedAt().toString();
+				
+				yield Base64.getUrlEncoder()
+						.encodeToString(rawCursor.getBytes(StandardCharsets.UTF_8));
+			}
+			case PRICE_HIGH, PRICE_LOW -> {
+				ProductDocument target = null;
+				for (int i = docs.size() - 1; i >= 0; i--) {
+					if (docs.get(i).getPricePerDay() != null) {
+						target = docs.get(i);
+						break;
+					}
+				}
+				
+				if (target == null) {
+					yield null;
+				}
+				
+				BigDecimal price = target.getPricePerDay();
+				Long id = target.getId();
+				
+				yield price.toPlainString() + ":" + id;
+			}
+		};
+	}
 
     // 상품에 이미지 추가하기
     private void addImages(Product product, List<String> imageUrls) {
@@ -161,10 +282,17 @@ public class ProductService {
     }
 
     // 상품 상태 변경
-    private void changeStatus(Long productId, ProductStatus status) {
+    private void changeStatus(Long memberId, Long productId, ProductStatus status) {
 
         Product product = repository.findById(productId)
                 .orElseThrow(() -> new IllegalArgumentException("PRODUCT NOT FOUND: " + productId));
+		
+		Long sellerId = sellerFeignClient.findSellerById(memberId).sellerId();
+		
+		if (!sellerId.equals(product.getSellerId())) {
+			throw new IllegalArgumentException("해당 상품의 상태 변경 권한이 없습니다.");
+		}
+		
         product.updateStatus(status);
 
         if (status == ProductStatus.DELETE) {

--- a/modi/product-service/src/main/java/com/coc/modi/product/application/dto/ProductScrollResponse.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/application/dto/ProductScrollResponse.java
@@ -1,0 +1,10 @@
+package com.coc.modi.product.application.dto;
+
+import java.util.List;
+
+public record ProductScrollResponse(
+		List<ProductListResponse> products,
+		String nextCursor,
+		boolean hasNext
+) {
+}

--- a/modi/product-service/src/main/java/com/coc/modi/product/application/dto/ProductSearchCondition.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/application/dto/ProductSearchCondition.java
@@ -1,26 +1,27 @@
 package com.coc.modi.product.application.dto;
 
 import com.coc.modi.product.domain.ProductCategory;
+import com.coc.modi.product.search.ProductSortType;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
 public record ProductSearchCondition(
         String keyword,            // 키워드 (name / description)
         ProductCategory category,  // 카테고리
         BigDecimal minPrice,       // 최저 일일 가격
         BigDecimal maxPrice,       // 최고 일일 가격
-        Long sellerId
+        Long sellerId,
+		LocalDate startDate,
+		LocalDate endDate,
+		ProductSortType sortType
 ) {
-    
-    public boolean isEmpty() {
-        return (keyword == null || keyword.isBlank()) &&
-                category == null &&
-                minPrice == null &&
-                maxPrice == null &&
-                sellerId == null;
-    }
-
-    public boolean isNotEmpty() {
-        return !isEmpty();
-    }
+	
+	public boolean hasRentalPeriod() {
+		return startDate != null && endDate != null;
+	}
+	
+	public ProductSortType effectiveSortType() {
+		return sortType != null ? sortType : ProductSortType.LATEST;
+	}
 }

--- a/modi/product-service/src/main/java/com/coc/modi/product/application/dto/RentalResponse.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/application/dto/RentalResponse.java
@@ -1,0 +1,8 @@
+package com.coc.modi.product.application.dto;
+
+import java.util.List;
+
+public record RentalResponse(
+		List<Long> unavailableProductIds
+) {
+}

--- a/modi/product-service/src/main/java/com/coc/modi/product/application/dto/SellerResponse.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/application/dto/SellerResponse.java
@@ -1,0 +1,6 @@
+package com.coc.modi.product.application.dto;
+
+public record SellerResponse(
+		Long sellerId
+) {
+}

--- a/modi/product-service/src/main/java/com/coc/modi/product/domain/Product.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/domain/Product.java
@@ -12,10 +12,12 @@ import java.util.stream.Collectors;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import com.coc.modi.common.BaseEntity;
+
 @Getter
 @Entity
 @Table(name = "product", schema = "public")
-public class Product {
+public class Product extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)

--- a/modi/product-service/src/main/java/com/coc/modi/product/domain/ProductImage.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/domain/ProductImage.java
@@ -5,10 +5,12 @@ import lombok.Getter;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import com.coc.modi.common.BaseEntity;
+
 @Getter
 @Entity
 @Table(name = "product_image", schema = "public")
-public class ProductImage {
+public class ProductImage extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)

--- a/modi/product-service/src/main/java/com/coc/modi/product/infrastructure/client/RentalFeignClient.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/infrastructure/client/RentalFeignClient.java
@@ -1,0 +1,19 @@
+package com.coc.modi.product.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.coc.modi.product.application.dto.RentalResponse;
+import com.coc.modi.product.presentation.dto.RentalRequest;
+
+@FeignClient(
+		name = "rental-service",
+		url = "${rental-service.url}",
+		path = "/internal/rentals"
+)
+public interface RentalFeignClient {
+	
+	@PostMapping("/unavailable-products")
+	RentalResponse unavailableProducts(@RequestBody RentalRequest rentalRequest);
+}

--- a/modi/product-service/src/main/java/com/coc/modi/product/infrastructure/client/SellerFeignClient.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/infrastructure/client/SellerFeignClient.java
@@ -1,0 +1,18 @@
+package com.coc.modi.product.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.coc.modi.product.application.dto.SellerResponse;
+
+@FeignClient(
+		name = "seller-service",
+		url = "${seller-service.url}",
+		path = "/internal/sellers"
+)
+public interface SellerFeignClient {
+	
+	@GetMapping("/{memberId}")
+	SellerResponse findSellerById(@PathVariable("memberId") Long memberId);
+}

--- a/modi/product-service/src/main/java/com/coc/modi/product/presentation/ProductController.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/presentation/ProductController.java
@@ -3,14 +3,14 @@ package com.coc.modi.product.presentation;
 import com.coc.modi.common.ApiResponse;
 import com.coc.modi.product.application.ProductService;
 import com.coc.modi.product.application.dto.*;
-import com.coc.modi.product.presentation.dto.ProductRequestDto;
-import com.coc.modi.product.presentation.dto.ProductUpdateRequestDto;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import com.coc.modi.product.presentation.dto.ProductRequest;
+import com.coc.modi.product.presentation.dto.ProductUpdateRequest;
+import com.coc.modi.product.search.ProductSortType;
 
-import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,11 +21,13 @@ public class ProductController {
 
     // 상품 목록 조회
     @GetMapping
-    public ResponseEntity<ApiResponse<List<ProductListResponse>>> getProducts(
+    public ResponseEntity<ApiResponse<ProductScrollResponse>> getProducts(
             @ModelAttribute ProductSearchCondition condition,
-            Pageable pageable) {
+			@RequestParam(required = false) String cursor,
+			@RequestParam(defaultValue = "20") int size,
+			@RequestParam(defaultValue = "LATEST") ProductSortType sortType) {
 
-        return ResponseEntity.ok(ApiResponse.ok(service.searchProducts(condition, pageable)));
+        return ResponseEntity.ok(ApiResponse.ok(service.searchProducts(condition, cursor, size, sortType)));
     }
 
     // 상품 상세 조회
@@ -37,10 +39,9 @@ public class ProductController {
 
     // 상품 등록
     @PostMapping
-    public ResponseEntity<ApiResponse<ProductResponse>> createProduct(@RequestBody ProductRequestDto request) {
-
-        // TODO: sellerId 연결
-        Long sellerId = 0L;
+    public ResponseEntity<ApiResponse<ProductResponse>> createProduct(Authentication authentication, @RequestBody ProductRequest request) {
+		
+		Long memberId = (Long) authentication.getPrincipal();
 
         ProductCommand command = new ProductCommand(
                 request.name(),
@@ -50,13 +51,16 @@ public class ProductController {
                 request.images()
         );
 
-        return ResponseEntity.ok(ApiResponse.ok(service.createProduct(sellerId, command)));
+        return ResponseEntity.ok(ApiResponse.ok(service.createProduct(memberId, command)));
     }
 
     // 상품 수정
     @PutMapping("/{productId}")
-    public ResponseEntity<ApiResponse<ProductResponse>> updateProduct(@PathVariable("productId") Long productId,
-                                                                      @RequestBody ProductUpdateRequestDto request) {
+    public ResponseEntity<ApiResponse<ProductResponse>> updateProduct(Authentication authentication,
+																	  @PathVariable("productId") Long productId,
+                                                                      @RequestBody ProductUpdateRequest request) {
+		
+		Long memberId = (Long) authentication.getPrincipal();
 
         ProductUpdateCommand command = new ProductUpdateCommand(
                 request.name(),
@@ -66,23 +70,29 @@ public class ProductController {
                 request.images()
         );
 
-        return ResponseEntity.ok(ApiResponse.ok(service.updateProduct(productId, command)));
+        return ResponseEntity.ok(ApiResponse.ok(service.updateProduct(memberId, productId, command)));
     }
 
     // 상품 숨김
     @PatchMapping("/{productId}")
-    public ResponseEntity<ApiResponse<?>> disableProduct(@PathVariable("productId") Long productId) {
+    public ResponseEntity<ApiResponse<?>> disableProduct(Authentication authentication,
+														 @PathVariable("productId") Long productId) {
+		
+		Long memberId = (Long) authentication.getPrincipal();
 
-        service.disableProduct(productId);
+        service.disableProduct(memberId, productId);
 
         return ResponseEntity.ok(ApiResponse.ok());
     }
 
     // 상품 삭제
     @DeleteMapping("/{productId}")
-    public ResponseEntity<ApiResponse<?>> deleteProduct(@PathVariable("productId") Long productId) {
+    public ResponseEntity<ApiResponse<?>> deleteProduct(Authentication authentication,
+														@PathVariable("productId") Long productId) {
+		
+		Long memberId = (Long) authentication.getPrincipal();
 
-        service.deleteProduct(productId);
+        service.deleteProduct(memberId, productId);
 
         return ResponseEntity.ok(ApiResponse.ok());
     }

--- a/modi/product-service/src/main/java/com/coc/modi/product/presentation/dto/ProductRequest.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/presentation/dto/ProductRequest.java
@@ -3,7 +3,7 @@ package com.coc.modi.product.presentation.dto;
 import java.math.BigDecimal;
 import java.util.List;
 
-public record ProductRequestDto(
+public record ProductRequest(
         String name,
         String description,
         BigDecimal pricePerDay,

--- a/modi/product-service/src/main/java/com/coc/modi/product/presentation/dto/ProductUpdateRequest.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/presentation/dto/ProductUpdateRequest.java
@@ -5,7 +5,7 @@ import com.coc.modi.product.application.dto.ProductResponse;
 import java.math.BigDecimal;
 import java.util.List;
 
-public record ProductUpdateRequestDto(
+public record ProductUpdateRequest(
         String name,
         String description,
         BigDecimal pricePerDay,

--- a/modi/product-service/src/main/java/com/coc/modi/product/presentation/dto/RentalRequest.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/presentation/dto/RentalRequest.java
@@ -1,0 +1,11 @@
+package com.coc.modi.product.presentation.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record RentalRequest(
+		LocalDate startDate,
+		LocalDate endDate,
+		List<Long> ProductIds
+) {
+}

--- a/modi/product-service/src/main/java/com/coc/modi/product/search/ProductDocument.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/search/ProductDocument.java
@@ -1,14 +1,14 @@
 package com.coc.modi.product.search;
 
 import com.coc.modi.product.domain.Product;
-import com.coc.modi.product.domain.ProductStatus;
-import com.coc.modi.product.domain.ProductCategory;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.*;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 @Getter
 @NoArgsConstructor
@@ -43,6 +43,9 @@ public class ProductDocument {
 
     @Field(type = FieldType.Keyword)
     private String thumbnailUrl;
+	
+	@Field(type = FieldType.Date, format = DateFormat.date_time)
+	private OffsetDateTime createdAt;
 
     public ProductDocument(Long id,
                            String name,
@@ -51,7 +54,8 @@ public class ProductDocument {
                            String status,
                            Long sellerId,
                            String category,
-                           String thumbnailUrl) {
+                           String thumbnailUrl,
+						   OffsetDateTime createdAt) {
         this.id = id;
         this.name = name;
         this.description = description;
@@ -60,9 +64,16 @@ public class ProductDocument {
         this.sellerId = sellerId;
         this.category = category;
         this.thumbnailUrl = thumbnailUrl;
+		this.createdAt = createdAt;
     }
 
     public static ProductDocument from(Product product, String thumbnailUrl) {
+		
+		OffsetDateTime createdAt = null;
+		if (product.getCreatedAt() != null) {
+			createdAt = product.getCreatedAt().atOffset(ZoneOffset.of("+09:00"));
+		}
+		
         return new ProductDocument(
                 product.getId(),
                 product.getName(),
@@ -71,15 +82,8 @@ public class ProductDocument {
                 product.getStatus().name(),
                 product.getSellerId(),
                 product.getCategory().name(),
-                thumbnailUrl
+                thumbnailUrl,
+				createdAt
         );
-    }
-
-    public ProductStatus toStatusEnum() {
-        return ProductStatus.valueOf(this.status);
-    }
-
-    public ProductCategory toCategoryEnum() {
-        return ProductCategory.valueOf(this.category);
     }
 }

--- a/modi/product-service/src/main/java/com/coc/modi/product/search/ProductSearchQueryRepository.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/search/ProductSearchQueryRepository.java
@@ -3,17 +3,22 @@ package com.coc.modi.product.search;
 import com.coc.modi.product.application.dto.ProductSearchCondition;
 import com.coc.modi.product.domain.ProductCategory;
 import com.coc.modi.product.domain.ProductStatus;
+
+import co.elastic.clients.elasticsearch._types.SortOrder;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 
 @Repository
@@ -22,59 +27,187 @@ public class ProductSearchQueryRepository {
 
     private final ElasticsearchOperations operations;
 
-    public Page<ProductDocument> search(ProductSearchCondition cond, Pageable pageable) {
+    public List<ProductDocument> search(
+			ProductSearchCondition cond,
+			String cursor,
+			int size,
+			ProductSortType sortType) {
+		
+		Pageable pageable = PageRequest.of(0, size);
 
-        NativeQuery query = NativeQuery.builder()
-                .withQuery(q -> q
-                        .bool(b -> {
-                            // status ACTIVE 필터
-                            b. filter(f -> f.term(t -> t.field("status").value(ProductStatus.ACTIVE.name())));
-                            
-                            // 키워드 필터(name, description)
-                            if (StringUtils.hasText(cond.keyword())) {
-                                b.must(m -> m
-                                        .multiMatch(mm -> mm.fields("name", "description").query(cond.keyword())));
-                            }
-                            
-                            // 카테고리 필터
-                            if(cond.category() != null) {
-                                ProductCategory category = cond.category();
-                                b.filter(f -> f.term(t -> t.field("category").value(category.name())));
-                            }
-                            
-                            // 가격 범위 필터
-                            if(cond.minPrice() != null || cond.maxPrice() != null) {
-                                b.filter(f -> f.range(r -> r.number(n -> {
-                                    n.field("pricePerDay");
+        NativeQueryBuilder builder = NativeQuery.builder();
+		builder.withQuery(q -> q
+				.bool(b -> {
+					// status ACTIVE 필터
+					b. filter(f -> f.term(t -> t.field("status").value(ProductStatus.ACTIVE.name())));
 
-                                    if(cond.minPrice() != null) {
-                                        n.gte(cond.minPrice().doubleValue());
-                                    }
-                                    if(cond.maxPrice() != null) {
-                                        n.lte(cond.maxPrice().doubleValue());
-                                    }
+					// 키워드 필터(name, description)
+					if (StringUtils.hasText(cond.keyword())) {
+						b.must(m -> m
+								.multiMatch(mm -> mm.fields("name", "description").query(cond.keyword())));
+					}
+						
+					// 카테고리 필터
+					if(cond.category() != null) {
+						ProductCategory category = cond.category();
+						b.filter(f -> f.term(t -> t.field("category").value(category.name())));
+					}
+							
+					// 가격 범위 필터
+					if(cond.minPrice() != null || cond.maxPrice() != null) {
+						b.filter(f -> f.range(r -> r.number(n -> {
+							n.field("pricePerDay");
 
-                                    return n;
-                                })));
-                            }
-                            
-                            // 판매자 필터
-                            if(cond.sellerId() != null) {
-                                b.filter(f -> f
-                                        .term(t -> t.field("sellerId").value(cond.sellerId())));
-                            }
-                            
-                            return b;
-                        }))
-                .withPageable(pageable).build();
+							if(cond.minPrice() != null) {
+								n.gte(cond.minPrice().doubleValue());
+							}
+							if(cond.maxPrice() != null) {
+								n.lte(cond.maxPrice().doubleValue());
+							}
+
+							return n;
+						})));
+					}
+						
+					// 판매자 필터
+					if(cond.sellerId() != null) {
+						b.filter(f -> f
+								.term(t -> t.field("sellerId").value(cond.sellerId())));
+					}
+						
+					if (StringUtils.hasText(cursor)) {
+						switch (sortType) {
+							case LATEST -> {
+								try {
+									String decoded = new String(
+											Base64.getUrlDecoder().decode(cursor),
+											StandardCharsets.UTF_8
+									);
+									b.filter(f -> f.range(r -> r
+											.date(d -> d
+													.field("createdAt")
+													.lt(decoded))));
+								} catch (NumberFormatException ignored) {
+									// 잘못된 cursor면 그냥 첫 페이지처럼 동작
+								}
+							}
+							case OLDEST -> {
+								try {
+									String decoded = new String(
+											Base64.getUrlDecoder().decode(cursor),
+											StandardCharsets.UTF_8
+									);
+									b.filter(f -> f.range(r -> r
+											.date(d -> d
+													.field("createdAt")
+													.gt(decoded))));
+								} catch (NumberFormatException ignored) {
+									// 잘못된 cursor면 그냥 첫 페이지처럼 동작
+								}
+							}
+							case PRICE_HIGH -> {
+								try {
+									String[] parts = cursor.split(":", 2);
+									BigDecimal cursorPrice = new BigDecimal(parts[0]);
+									long cursorId = Long.parseLong(parts[1]);
+									
+									b.filter(f -> f.bool(bb -> bb
+											// pricePerDay < cursorPrice
+											.should(s -> s.range(r -> r.number(n -> n
+													.field("pricePerDay")
+													.lt(cursorPrice.doubleValue())
+											)))
+											// pricePerDay == cursorPrice AND id < cursorId
+											.should(s -> s.bool(bb2 -> bb2
+													.must(m -> m.term(t -> t
+															.field("pricePerDay")
+															.value(cursorPrice.doubleValue())
+													))
+													.must(m -> m.range(r -> r.number(n -> n
+															.field("id")
+															.lt((double)cursorId)
+													)))
+											))
+											.minimumShouldMatch("1")
+									));
+								} catch (NumberFormatException ignored) {
+									// cursor 파싱 실패하면 그냥 첫 페이지처럼 동작
+								}
+							}
+							case PRICE_LOW -> {
+								try {
+									String[] parts = cursor.split(":", 2);
+									BigDecimal cursorPrice = new BigDecimal(parts[0]);
+									long cursorId = Long.parseLong(parts[1]);
+									
+									b.filter(f -> f.bool(bb -> bb
+											// pricePerDay > cursorPrice
+											.should(s -> s.range(r -> r.number(n -> n
+													.field("pricePerDay")
+													.gt(cursorPrice.doubleValue())
+											)))
+											// pricePerDay == cursorPrice AND id > cursorId
+											.should(s -> s.bool(bb2 -> bb2
+													.must(m -> m.term(t -> t
+															.field("pricePerDay")
+															.value(cursorPrice.doubleValue())
+													))
+													.must(m -> m.range(r -> r.number(n -> n
+															.field("id")
+															.gt((double)cursorId)
+													)))
+											))
+											.minimumShouldMatch("1")
+									));
+								} catch (Exception ignored) {
+									// 잘못된 cursor 형식이면 무시하고 첫 페이지처럼
+								}
+							}
+							
+						}
+					}
+						
+					return b;
+				})
+		);
+		
+		switch (sortType) {
+			case LATEST -> builder.withSort(s -> s.field(f -> f
+					.field("createdAt")
+					.order(SortOrder.Desc)
+			));
+			case OLDEST -> builder.withSort(s -> s.field(f -> f
+					.field("createdAt")
+					.order(SortOrder.Asc)
+			));
+			case PRICE_HIGH -> {
+				// 가격 내림차순 + id 내림차순 (tie-breaker)
+				builder.withSort(s -> s.field(f -> f
+						.field("pricePerDay")
+						.order(SortOrder.Desc)
+				));
+				builder.withSort(s -> s.field(f -> f
+						.field("id")
+						.order(SortOrder.Desc)
+				));
+			}
+			case PRICE_LOW -> {
+				// 가격 오름차순 + id 오름차순 (tie-breaker)
+				builder.withSort(s -> s.field(f -> f
+						.field("pricePerDay")
+						.order(SortOrder.Asc)
+				));
+				builder.withSort(s -> s.field(f -> f
+						.field("id")
+						.order(SortOrder.Asc)
+				));
+			}
+		}
+		
+		NativeQuery query = builder.withPageable(pageable).build();
 
         SearchHits<ProductDocument> hits = operations.search(query, ProductDocument.class);
 
-        List<ProductDocument> content = hits.getSearchHits().stream()
-                .map(SearchHit::getContent).toList();
-
-        long total = hits.getTotalHits();
-
-        return new PageImpl<>(content, pageable, total);
+        return hits.getSearchHits().stream().map(SearchHit::getContent).toList();
     }
 }

--- a/modi/product-service/src/main/java/com/coc/modi/product/search/ProductSortType.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/search/ProductSortType.java
@@ -1,0 +1,8 @@
+package com.coc.modi.product.search;
+
+public enum ProductSortType {
+	LATEST,       // createdAt DESC
+	OLDEST,       // createdAt ASC
+	PRICE_HIGH,   // pricePerDay DESC
+	PRICE_LOW     // pricePerDay ASC
+}


### PR DESCRIPTION
## 개요
상품 리스트 조회 기능을 기존 페이지네이션 방식에서 커서 기반 스크롤 방식으로 전환
판매자 정보·대여 가능 여부를 Feign Client를 통해 조회하도록 기능 추가

## 변경 사항
🔹 신규 파일 추가
- ProductScrollResponse
- ProductSortType
- RentalFeignClient, RentalRequest, RentalResponse
- SellerFeignClient, SellerResponse

🔹 상품 조회 기능 개편
- 상품 목록 조회 시 createdAt/pricePerDay 기반 정렬 방식(LATEST/OLDEST/PRICE_HIGH/PRICE_LOW) 추가
- 기존 offset/page 기반에서 cursor 기반 조회 방식으로 전환
→ last document 기준으로 nextCursor 생성하여 스크롤 형태 지원
- cursor 기반 날짜 비교 시 Base64 인코딩 및 안전 처리 로직 추가

🔹 내부 API 연동
- 판매자 정보 조회 → SellerFeignClient 사용
- 대여 불가 상품 조회 → RentalFeignClient 사용
- 검색 결과 중 대여 불가 상품을 제외하는 로직 추가

🔹 기존 코드 수정
- ProductService
   - 커서 기반 조회 로직 추가
   - nextCursor 생성 로직 구현
   - 정렬 조건 및 대여 불가 상품 필터링 추가
- ProductSearchQueryRepository
   - 정렬 조건 기반 ES Query 구성
   - cursor 기반 range 필터 적용
- ProductSearchCondition
   - 날짜/가격 정렬 관련 필드 확장
- ProductDocument
   - 검색/정렬에 필요한 필드 매핑
- ProductController
   - API 요청/응답 구조를 cursor 기반에 맞게 변경

## 관련 이슈
## 테스트
[ o ] 로컬 빌드 성공
[ o ] API 테스트 완료
## 리뷰 요청 사항