### PR TITLE
feat : 내부 API 추가

### DIFF
--- a/modi/.gitignore
+++ b/modi/.gitignore
@@ -10,7 +10,6 @@ HELP.md
 !**/src/test/**/build/
 **/src/main/generated/
 **/src/main/resources/application.yml
-.idea
 *.yml
 .env
 ### STS ###

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/seller/application/dto/SellerIdResponse.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/seller/application/dto/SellerIdResponse.java
@@ -1,0 +1,4 @@
+package com.coc.modi.seller.seller.application.dto;
+
+public record SellerIdResponse(Long sellerId) {
+}

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/seller/presentation/SellerController.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/seller/presentation/SellerController.java
@@ -3,6 +3,7 @@ package com.coc.modi.seller.seller.presentation;
 import com.coc.modi.common.ApiResponse;
 import com.coc.modi.seller.seller.application.SellerService;
 import com.coc.modi.seller.application.dto.SellerRentalResponse;
+import com.coc.modi.seller.seller.application.dto.SellerIdResponse;
 import com.coc.modi.seller.seller.application.dto.SellerResponse;
 import com.coc.modi.seller.seller.presentation.dto.SellerCreateRequest;
 import com.coc.modi.seller.seller.presentation.dto.SellerUpdateRequest;
@@ -60,6 +61,12 @@ public class SellerController {
     @GetMapping("/internal/sellers/by-member/{memberId}")
     public SellerResponse getSellerByMemberId(@PathVariable Long memberId) {
         return sellerService.getSellerByMemberId(memberId);
+    }
+
+    @GetMapping("/internal/sellers/member/{memberId}/id")
+    public SellerIdResponse getSellerIdByMemberId(@PathVariable Long memberId) {
+        SellerResponse seller = sellerService.getSellerByMemberId(memberId);
+        return new SellerIdResponse(seller.id());
     }
 
     @GetMapping("/internal/sellers/{sellerId}")


### PR DESCRIPTION
 - Endpoint: GET /internal/sellers/member/{memberId}/id
  - Path Variable: memberId (Long)
  - Response 200 (application/json):

    {
      "sellerId": 1
    }

 엔드포인트: 기존 /internal/sellers/{sellerId}와 패턴 충돌을 피하려고
 새 경로를 GET /internal/sellers/member/{memberId}/id로 추가했습니다.