### PR TITLE
feat :  커스텀 예외 추가

### DIFF
--- a/modi/seller-service/src/main/java/com/coc/modi/seller/exception/SellerDuplicateException.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/exception/SellerDuplicateException.java
@@ -1,0 +1,15 @@
+package com.coc.modi.seller.exception;
+
+import com.coc.modi.common.BaseException;
+import com.coc.modi.common.ErrorCode;
+
+public class SellerDuplicateException extends BaseException {
+
+    public SellerDuplicateException() {
+        super(ErrorCode.CONFLICT, "이미 등록된 판매자입니다.");
+    }
+
+    public SellerDuplicateException(String detailMessage) {
+        super(ErrorCode.CONFLICT, detailMessage);
+    }
+}

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/exception/SellerNotFoundException.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/exception/SellerNotFoundException.java
@@ -1,0 +1,15 @@
+package com.coc.modi.seller.exception;
+
+import com.coc.modi.common.BaseException;
+import com.coc.modi.common.ErrorCode;
+
+public class SellerNotFoundException extends BaseException {
+
+    public SellerNotFoundException() {
+        super(ErrorCode.NOT_FOUND, "판매자를 찾을 수 없습니다.");
+    }
+
+    public SellerNotFoundException(String detailMessage) {
+        super(ErrorCode.NOT_FOUND, detailMessage);
+    }
+}

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/exception/SellerSettlementForbiddenException.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/exception/SellerSettlementForbiddenException.java
@@ -1,0 +1,15 @@
+package com.coc.modi.seller.exception;
+
+import com.coc.modi.common.BaseException;
+import com.coc.modi.common.ErrorCode;
+
+public class SellerSettlementForbiddenException extends BaseException {
+
+    public SellerSettlementForbiddenException() {
+        super(ErrorCode.FORBIDDEN, "정산서 소유자가 일치하지 않습니다.");
+    }
+
+    public SellerSettlementForbiddenException(String detailMessage) {
+        super(ErrorCode.FORBIDDEN, detailMessage);
+    }
+}

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/exception/SellerSettlementNotFoundException.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/exception/SellerSettlementNotFoundException.java
@@ -1,0 +1,15 @@
+package com.coc.modi.seller.exception;
+
+import com.coc.modi.common.BaseException;
+import com.coc.modi.common.ErrorCode;
+
+public class SellerSettlementNotFoundException extends BaseException {
+
+    public SellerSettlementNotFoundException() {
+        super(ErrorCode.NOT_FOUND, "정산서를 찾을 수 없습니다.");
+    }
+
+    public SellerSettlementNotFoundException(String detailMessage) {
+        super(ErrorCode.NOT_FOUND, detailMessage);
+    }
+}

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/exception/SettlementBatchDuplicateException.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/exception/SettlementBatchDuplicateException.java
@@ -1,0 +1,15 @@
+package com.coc.modi.seller.exception;
+
+import com.coc.modi.common.BaseException;
+import com.coc.modi.common.ErrorCode;
+
+public class SettlementBatchDuplicateException extends BaseException {
+
+    public SettlementBatchDuplicateException() {
+        super(ErrorCode.CONFLICT, "이미 생성된 정산 배치입니다.");
+    }
+
+    public SettlementBatchDuplicateException(String detailMessage) {
+        super(ErrorCode.CONFLICT, detailMessage);
+    }
+}

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/exception/SettlementBatchExecutionNotFoundException.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/exception/SettlementBatchExecutionNotFoundException.java
@@ -1,0 +1,15 @@
+package com.coc.modi.seller.exception;
+
+import com.coc.modi.common.BaseException;
+import com.coc.modi.common.ErrorCode;
+
+public class SettlementBatchExecutionNotFoundException extends BaseException {
+
+    public SettlementBatchExecutionNotFoundException() {
+        super(ErrorCode.NOT_FOUND, "배치 실행을 찾을 수 없습니다.");
+    }
+
+    public SettlementBatchExecutionNotFoundException(String detailMessage) {
+        super(ErrorCode.NOT_FOUND, detailMessage);
+    }
+}

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/exception/SettlementBatchNotFoundException.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/exception/SettlementBatchNotFoundException.java
@@ -1,0 +1,15 @@
+package com.coc.modi.seller.exception;
+
+import com.coc.modi.common.BaseException;
+import com.coc.modi.common.ErrorCode;
+
+public class SettlementBatchNotFoundException extends BaseException {
+
+    public SettlementBatchNotFoundException() {
+        super(ErrorCode.NOT_FOUND, "정산 배치를 찾을 수 없습니다.");
+    }
+
+    public SettlementBatchNotFoundException(String detailMessage) {
+        super(ErrorCode.NOT_FOUND, detailMessage);
+    }
+}

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/seller/application/SellerService.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/seller/application/SellerService.java
@@ -1,9 +1,9 @@
 package com.coc.modi.seller.seller.application;
 
-import com.coc.modi.common.BaseException;
-import com.coc.modi.common.ErrorCode;
 import com.coc.modi.seller.application.SellerRentalService;
 import com.coc.modi.seller.application.dto.SellerRentalResponse;
+import com.coc.modi.seller.exception.SellerDuplicateException;
+import com.coc.modi.seller.exception.SellerNotFoundException;
 import com.coc.modi.seller.seller.application.dto.SellerCreateCommand;
 import com.coc.modi.seller.seller.application.dto.SellerResponse;
 import com.coc.modi.seller.seller.application.dto.SellerUpdateCommand;
@@ -24,21 +24,21 @@ public class SellerService {
     @Transactional(readOnly = true)
     public SellerResponse getSeller(Long sellerId) {
         Seller seller = sellerRepository.findById(sellerId)
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND, "판매자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new SellerNotFoundException("판매자를 찾을 수 없습니다. id=" + sellerId));
         return SellerResponse.from(seller);
     }
 
     @Transactional(readOnly = true)
     public SellerResponse getSellerByMemberId(Long memberId) {
         Seller seller = sellerRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND, "판매자를 찾을 수 없습니다"));
+                .orElseThrow(() -> new SellerNotFoundException("판매자를 찾을 수 없습니다. memberId=" + memberId));
         return SellerResponse.from(seller);
     }
 
     @Transactional
     public SellerResponse registerSeller(SellerCreateCommand command) {
         if (sellerRepository.existsByMemberId(command.memberId())) {
-            throw new BaseException(ErrorCode.CONFLICT, "이미 등록된 판매자입니다.");
+            throw new SellerDuplicateException("이미 등록된 판매자입니다. memberId=" + command.memberId());
         }
 
         Seller seller = Seller.create(
@@ -56,7 +56,7 @@ public class SellerService {
     @Transactional
     public SellerResponse updateSellerByMemberId(Long memberId, SellerUpdateCommand command) {
         Seller seller = sellerRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND, "판매자를 찾을 수 없습니다"));
+                .orElseThrow(() -> new SellerNotFoundException("판매자를 찾을 수 없습니다. memberId=" + memberId));
 
         seller.update(
                 command.storeName(),
@@ -82,7 +82,7 @@ public class SellerService {
                                                    Integer page,
                                                    Integer size) {
         Seller seller = sellerRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND, "판매자를 찾을 수 없습니다"));
+                .orElseThrow(() -> new SellerNotFoundException("판매자를 찾을 수 없습니다. memberId=" + memberId));
         return sellerRentalService.getSellerRentals(
                 seller.getId(),
                 status,

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/settlement/application/SellerSettlementService.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/settlement/application/SellerSettlementService.java
@@ -1,7 +1,7 @@
 package com.coc.modi.seller.settlement.application;
 
-import com.coc.modi.common.BaseException;
-import com.coc.modi.common.ErrorCode;
+import com.coc.modi.seller.exception.SellerSettlementForbiddenException;
+import com.coc.modi.seller.exception.SellerSettlementNotFoundException;
 import com.coc.modi.seller.settlement.application.dto.SellerSettlementResponse;
 import com.coc.modi.seller.settlement.application.dto.SellerSettlementLineResponse;
 import com.coc.modi.seller.settlement.application.dto.SellerSettlementLineCommand;
@@ -76,10 +76,10 @@ public class SellerSettlementService {
 
     private SellerSettlement findOwnedSettlement(Long sellerId, Long sellerSettlementId) {
         SellerSettlement settlement = sellerSettlementRepository.findById(sellerSettlementId)
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND, "정산서를 찾을 수 없습니다. id=" + sellerSettlementId));
+                .orElseThrow(() -> new SellerSettlementNotFoundException("정산서를 찾을 수 없습니다. id=" + sellerSettlementId));
 
         if (!settlement.getSellerId().equals(sellerId)) {
-            throw new BaseException(ErrorCode.FORBIDDEN, "정산서 소유자가 일치하지 않습니다. sellerId=" + sellerId);
+            throw new SellerSettlementForbiddenException("정산서 소유자가 일치하지 않습니다. sellerId=" + sellerId);
         }
         return settlement;
     }

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/settlement/application/SettlementBatchExecutionService.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/settlement/application/SettlementBatchExecutionService.java
@@ -1,7 +1,6 @@
 package com.coc.modi.seller.settlement.application;
 
-import com.coc.modi.common.BaseException;
-import com.coc.modi.common.ErrorCode;
+import com.coc.modi.seller.exception.SettlementBatchExecutionNotFoundException;
 import com.coc.modi.seller.settlement.domain.SettlementBatchExecution;
 import com.coc.modi.seller.settlement.domain.SettlementBatchExecutionLog;
 import com.coc.modi.seller.settlement.domain.SettlementBatchExecutionLogRepository;
@@ -33,7 +32,7 @@ public class SettlementBatchExecutionService {
                          BigDecimal feeAmount,
                          String lastCursor) {
         SettlementBatchExecution execution = executionRepository.findById(executionId)
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND, "배치 실행을 찾을 수 없습니다. id=" + executionId));
+                .orElseThrow(() -> new SettlementBatchExecutionNotFoundException("배치 실행을 찾을 수 없습니다. id=" + executionId));
         execution.complete(totalCount, successCount, failCount, totalAmount, feeAmount, lastCursor);
     }
 
@@ -44,7 +43,7 @@ public class SettlementBatchExecutionService {
                      Integer failCount,
                      String lastCursor) {
         SettlementBatchExecution execution = executionRepository.findById(executionId)
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND, "배치 실행을 찾을 수 없습니다. id=" + executionId));
+                .orElseThrow(() -> new SettlementBatchExecutionNotFoundException("배치 실행을 찾을 수 없습니다. id=" + executionId));
         execution.fail(errorMessage, totalCount, successCount, failCount, lastCursor);
     }
 
@@ -57,7 +56,7 @@ public class SettlementBatchExecutionService {
                     Long durationMs,
                     String errorMessage) {
         SettlementBatchExecution execution = executionRepository.findById(executionId)
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND, "배치 실행을 찾을 수 없습니다. id=" + executionId));
+                .orElseThrow(() -> new SettlementBatchExecutionNotFoundException("배치 실행을 찾을 수 없습니다. id=" + executionId));
         SettlementBatchExecutionLog log = SettlementBatchExecutionLog.builder()
                 .execution(execution)
                 .stepName(stepName)

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/settlement/application/SettlementBatchService.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/settlement/application/SettlementBatchService.java
@@ -1,7 +1,7 @@
 package com.coc.modi.seller.settlement.application;
 
-import com.coc.modi.common.BaseException;
-import com.coc.modi.common.ErrorCode;
+import com.coc.modi.seller.exception.SettlementBatchDuplicateException;
+import com.coc.modi.seller.exception.SettlementBatchNotFoundException;
 import com.coc.modi.seller.settlement.application.dto.SettlementBatchCreateCommand;
 import com.coc.modi.seller.settlement.application.dto.SettlementBatchResponse;
 import com.coc.modi.seller.settlement.domain.SettlementBatch;
@@ -25,7 +25,7 @@ public class SettlementBatchService {
     public SettlementBatchResponse createBatch(SettlementBatchCreateCommand command) {
         settlementBatchRepository.findByPeriodYm(command.periodYm())
                 .ifPresent(batch -> {
-                    throw new BaseException(ErrorCode.CONFLICT, "이미 생성된 정산 배치입니다. periodYm=" + command.periodYm());
+                    throw new SettlementBatchDuplicateException("이미 생성된 정산 배치입니다. periodYm=" + command.periodYm());
                 });
 
         SettlementBatch batch = SettlementBatch.create(command.periodYm());
@@ -63,6 +63,6 @@ public class SettlementBatchService {
 
     private SettlementBatch findBatch(Long batchId) {
         return settlementBatchRepository.findById(batchId)
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND, "정산 배치를 찾을 수 없습니다. id=" + batchId));
+                .orElseThrow(() -> new SettlementBatchNotFoundException("정산 배치를 찾을 수 없습니다. id=" + batchId));
     }
 }


### PR DESCRIPTION
  - seller/settlement 도메인별 커스텀 예외 클래스를 추가하고 서비스 로직에서 BaseException 대신 의미 있는 예외로 교체
  - 판매자/정산/배치 관련 예외 메시지를 한글로 정리
  - GlobalExceptionHandler는 유지, BaseException 흐름을 그대로 사용