### PR TITLE
feat: 리뷰 서비스 도메인 신규 추가 및 API 구현

### DIFF
--- a/modi/common/src/main/java/com/coc/modi/common/ErrorCode.java
+++ b/modi/common/src/main/java/com/coc/modi/common/ErrorCode.java
@@ -18,7 +18,10 @@ public enum ErrorCode {
 	RENTAL_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "RENTAL-ITEM-404", "대여 아이템 정보를 찾을 수 없습니다."),
 	RENTAL_STATUS_INVALID(HttpStatus.CONFLICT, "RENTAL-409", "허용되지 않은 대여 상태 변경입니다."),
 	RENTAL_MEMBER_MISMATCH(HttpStatus.FORBIDDEN, "RENTAL-403", "대여 요청자와 요청 멤버가 일치하지 않습니다."),
-	RENTAL_SELLER_MISMATCH(HttpStatus.FORBIDDEN, "RENTAL-SELLER-403", "판매자 정보가 일치하지 않습니다.");
+	RENTAL_SELLER_MISMATCH(HttpStatus.FORBIDDEN, "RENTAL-SELLER-403", "판매자 정보가 일치하지 않습니다."),
+
+	REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW-404", "리뷰를 찾을 수 없습니다."),
+	REVIEW_FORBIDDEN(HttpStatus.FORBIDDEN, "REVIEW-403", "리뷰 접근 권한이 없습니다.");
 	
 	private final HttpStatus status;
 	private final String code;

--- a/modi/review-service/build.gradle
+++ b/modi/review-service/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    // 공통 모듈
+    implementation project(":common")
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/ReviewServiceApplication.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/ReviewServiceApplication.java
@@ -1,0 +1,16 @@
+package com.coc.modi.review;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@EnableFeignClients(basePackages = "com.coc.modi")
+@SpringBootApplication(scanBasePackages = "com.coc.modi")
+public class ReviewServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ReviewServiceApplication.class, args);
+    }
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/application/ReviewService.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/application/ReviewService.java
@@ -1,0 +1,109 @@
+package com.coc.modi.review.application;
+
+import com.coc.modi.review.application.dto.CreateReviewCommand;
+import com.coc.modi.review.application.dto.ReviewResponse;
+import com.coc.modi.review.application.dto.ReviewSummaryResponse;
+import com.coc.modi.review.application.dto.UpdateReviewCommand;
+import com.coc.modi.review.domain.Review;
+import com.coc.modi.review.domain.ReviewRepository;
+import com.coc.modi.review.domain.ReviewStatus;
+import com.coc.modi.review.exception.ReviewAccessDeniedException;
+import com.coc.modi.review.exception.ReviewNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+	private final ReviewRepository reviewRepository;
+	
+	// 판매자 리뷰 생성
+	@Transactional
+	public ReviewResponse createReview(CreateReviewCommand command) {
+		
+		Review review = Review.create(
+				command.rentalId(),
+				command.sellerId(),
+				command.memberId(),
+				command.rating(),
+				command.content()
+		);
+
+		Review saved = reviewRepository.save(review);
+		
+		return ReviewResponse.from(saved);
+	}
+	
+	// 작성자가 본인 리뷰를 수정
+	@Transactional
+	public ReviewResponse updateReview(UpdateReviewCommand command) {
+		
+		Review review = reviewRepository.findByIdAndStatus(command.reviewId(), ReviewStatus.ACTIVE)
+				.orElseThrow(() -> new ReviewNotFoundException(command.reviewId()));
+
+		validateOwnership(review, command.memberId());
+
+		review.update(command.rating(), command.content());
+		
+		return ReviewResponse.from(review);
+	}
+	
+	// 작성자가 본인 리뷰를 소프트 삭제
+	@Transactional
+	public void deleteReview(Long reviewId, Long memberId) {
+		
+		Review review = reviewRepository.findByIdAndStatus(reviewId, ReviewStatus.ACTIVE)
+				.orElseThrow(() -> new ReviewNotFoundException(reviewId));
+
+		validateOwnership(review, memberId);
+
+		review.delete();
+	}
+	
+	// 단건 리뷰 조회 (삭제된 리뷰 제외)
+	@Transactional(readOnly = true)
+	public ReviewResponse getReview(Long reviewId) {
+		
+		return reviewRepository.findByIdAndStatus(reviewId, ReviewStatus.ACTIVE)
+				.map(ReviewResponse::from)
+				.orElseThrow(() -> new ReviewNotFoundException(reviewId));
+	}
+	
+	// 특정 판매자 리뷰 목록 조회 (삭제된 리뷰 제외)
+	@Transactional(readOnly = true)
+	public List<ReviewSummaryResponse> getReviewsBySeller(Long sellerId, Pageable pageable) {
+		
+		Page<Review> reviews = reviewRepository.findBySellerIdAndStatus(sellerId, ReviewStatus.ACTIVE, pageable);
+
+		return reviews.stream()
+				.map(ReviewSummaryResponse::from)
+				.toList();
+	}
+	
+	// 내가 작성한 리뷰 목록 조회 (삭제된 리뷰 제외)
+	@Transactional(readOnly = true)
+	public List<ReviewSummaryResponse> getReviewsByMember(Long memberId, Pageable pageable) {
+		
+		Page<Review> reviews = reviewRepository.findByMemberIdAndStatus(memberId, ReviewStatus.ACTIVE, pageable);
+
+		return reviews.stream()
+				.map(ReviewSummaryResponse::from)
+				.toList();
+	}
+
+	private void validateOwnership(Review review, Long memberId) {
+		
+		if (!review.getMemberId().equals(memberId)) {
+			
+			throw new ReviewAccessDeniedException();
+		}
+	}
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/application/dto/CreateReviewCommand.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/application/dto/CreateReviewCommand.java
@@ -1,0 +1,10 @@
+package com.coc.modi.review.application.dto;
+
+public record CreateReviewCommand(
+		Long rentalId,
+		Long sellerId,
+		Long memberId,
+		Short rating,
+		String content
+) {
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/application/dto/ReviewResponse.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/application/dto/ReviewResponse.java
@@ -1,0 +1,31 @@
+package com.coc.modi.review.application.dto;
+
+import com.coc.modi.review.domain.Review;
+
+import java.time.LocalDateTime;
+
+public record ReviewResponse(
+		Long id,
+		Long rentalId,
+		Long sellerId,
+		Long memberId,
+		Short rating,
+		String content,
+		LocalDateTime createdAt,
+		LocalDateTime updatedAt
+) {
+
+	public static ReviewResponse from(Review review) {
+		
+		return new ReviewResponse(
+				review.getId(),
+				review.getRentalId(),
+				review.getSellerId(),
+				review.getMemberId(),
+				review.getRating(),
+				review.getContent(),
+				review.getCreatedAt(),
+				review.getUpdatedAt()
+		);
+	}
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/application/dto/ReviewSummaryResponse.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/application/dto/ReviewSummaryResponse.java
@@ -1,0 +1,29 @@
+package com.coc.modi.review.application.dto;
+
+import com.coc.modi.review.domain.Review;
+
+import java.time.LocalDateTime;
+
+public record ReviewSummaryResponse(
+		Long id,
+		Long rentalId,
+		Long sellerId,
+		Long memberId,
+		Short rating,
+		String content,
+		LocalDateTime createdAt
+) {
+
+	public static ReviewSummaryResponse from(Review review) {
+		
+		return new ReviewSummaryResponse(
+				review.getId(),
+				review.getRentalId(),
+				review.getSellerId(),
+				review.getMemberId(),
+				review.getRating(),
+				review.getContent(),
+				review.getCreatedAt()
+		);
+	}
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/application/dto/UpdateReviewCommand.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/application/dto/UpdateReviewCommand.java
@@ -1,0 +1,9 @@
+package com.coc.modi.review.application.dto;
+
+public record UpdateReviewCommand(
+		Long reviewId,
+		Long memberId,
+		Short rating,
+		String content
+) {
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/domain/Review.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/domain/Review.java
@@ -1,0 +1,93 @@
+package com.coc.modi.review.domain;
+
+import com.coc.modi.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name = "review", schema = "public")
+public class Review extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "rental_id", nullable = false)
+	private Long rentalId;
+
+	@Column(name = "seller_id", nullable = false)
+	private Long sellerId;
+
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	@Column(name = "rating", nullable = false)
+	private Short rating;
+
+	@Column(name = "content", nullable = false, columnDefinition = "text")
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false, length = 20, columnDefinition = "varchar(20) default 'ACTIVE'")
+	private ReviewStatus status;
+
+	@Builder
+	private Review(Long rentalId, Long sellerId, Long memberId, Short rating, String content) {
+
+		validateRating(rating);
+		
+		this.rentalId = rentalId;
+		this.sellerId = sellerId;
+		this.memberId = memberId;
+		this.rating = rating;
+		this.content = content;
+		this.status = ReviewStatus.ACTIVE;
+	}
+
+	public static Review create(Long rentalId, Long sellerId, Long memberId, Short rating, String content) {
+
+		return Review.builder()
+				.rentalId(rentalId)
+				.sellerId(sellerId)
+				.memberId(memberId)
+				.rating(rating)
+				.content(content)
+				.build();
+	}
+
+	public void update(Short rating, String content) {
+
+		if (rating != null) {
+			validateRating(rating);
+			this.rating = rating;
+		}
+
+		if (content != null) {
+			this.content = content;
+		}
+	}
+
+	private void validateRating(Short rating) {
+
+		if (rating == null || rating < 1 || rating > 5) {
+			throw new IllegalArgumentException("리뷰 평점은 1~5 사이여야 합니다.");
+		}
+	}
+
+	public void delete() {
+		
+		this.status = ReviewStatus.DELETED;
+	}
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/domain/ReviewRepository.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/domain/ReviewRepository.java
@@ -1,0 +1,17 @@
+package com.coc.modi.review.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface ReviewRepository {
+
+	Review save(Review review);
+
+	Optional<Review> findByIdAndStatus(Long reviewId, ReviewStatus status);
+
+	Page<Review> findBySellerIdAndStatus(Long sellerId, ReviewStatus status, Pageable pageable);
+
+	Page<Review> findByMemberIdAndStatus(Long memberId, ReviewStatus status, Pageable pageable);
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/domain/ReviewStatus.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/domain/ReviewStatus.java
@@ -1,0 +1,6 @@
+package com.coc.modi.review.domain;
+
+public enum ReviewStatus {
+	ACTIVE,
+	DELETED
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/exception/GlobalExceptionHandler.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/exception/GlobalExceptionHandler.java
@@ -1,0 +1,84 @@
+package com.coc.modi.review.exception;
+
+import com.coc.modi.common.ApiResponse;
+import com.coc.modi.common.BaseException;
+import com.coc.modi.common.ErrorCode;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice(basePackages = "com.coc.modi.review")
+public class GlobalExceptionHandler {
+	
+	private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+	
+	@ExceptionHandler(BaseException.class)
+	public ResponseEntity<ApiResponse<?>> handleBaseException(BaseException ex) {
+		
+		ErrorCode errorCode = ex.getErrorCode();
+		String message = ex.getDetailMessage();
+		
+		log.warn("Business exception: code={}, message={}", errorCode.getCode(), message);
+		
+		return ResponseEntity
+				.status(errorCode.getStatus())
+				.body(ApiResponse.error(errorCode, message));
+	}
+	
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ApiResponse<?>> handleIllegalArgument(IllegalArgumentException ex) {
+		
+		log.warn("Illegal argument: {}", ex.getMessage());
+		
+		return buildResponse(ErrorCode.INVALID_INPUT, ex.getMessage());
+	}
+	
+	@ExceptionHandler(IllegalStateException.class)
+	public ResponseEntity<ApiResponse<?>> handleIllegalState(IllegalStateException ex) {
+		
+		log.warn("Illegal state: {}", ex.getMessage());
+		
+		return buildResponse(ErrorCode.CONFLICT, ex.getMessage());
+	}
+	
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ApiResponse<?>> handleValidation(MethodArgumentNotValidException ex) {
+		
+		String message = Optional.ofNullable(ex.getBindingResult())
+				.map(bindingResult -> bindingResult.getFieldErrors()
+						.stream()
+						.map(error -> error.getField() + ": " + error.getDefaultMessage())
+						.collect(Collectors.joining(", ")))
+				.filter(str -> !str.isBlank())
+				.orElse(ErrorCode.INVALID_INPUT.getDefaultMessage());
+		
+		log.warn("Validation error: {}", message);
+		
+		return buildResponse(ErrorCode.INVALID_INPUT, message);
+	}
+	
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ApiResponse<?>> handleUnexpected(Exception ex) {
+		
+		log.error("Unexpected error", ex);
+		
+		return buildResponse(ErrorCode.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getDefaultMessage());
+	}
+	
+	private ResponseEntity<ApiResponse<?>> buildResponse(ErrorCode errorCode, String message) {
+		
+		HttpStatus status = errorCode.getStatus();
+		
+		return ResponseEntity
+				.status(status)
+				.body(ApiResponse.error(errorCode, message));
+	}
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/exception/ReviewAccessDeniedException.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/exception/ReviewAccessDeniedException.java
@@ -1,0 +1,11 @@
+package com.coc.modi.review.exception;
+
+import com.coc.modi.common.ErrorCode;
+
+public class ReviewAccessDeniedException extends ReviewException {
+
+	public ReviewAccessDeniedException() {
+		
+		super(ErrorCode.REVIEW_FORBIDDEN, "리뷰 작성자만 수정/삭제할 수 있습니다.");
+	}
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/exception/ReviewException.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/exception/ReviewException.java
@@ -1,0 +1,16 @@
+package com.coc.modi.review.exception;
+
+import com.coc.modi.common.BaseException;
+import com.coc.modi.common.ErrorCode;
+
+public class ReviewException extends BaseException {
+
+	public ReviewException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public ReviewException(ErrorCode errorCode, String message) {
+		
+		super(errorCode, message);
+	}
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/exception/ReviewNotFoundException.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/exception/ReviewNotFoundException.java
@@ -1,0 +1,11 @@
+package com.coc.modi.review.exception;
+
+import com.coc.modi.common.ErrorCode;
+
+public class ReviewNotFoundException extends ReviewException {
+
+	public ReviewNotFoundException(Long reviewId) {
+		
+		super(ErrorCode.REVIEW_NOT_FOUND, "리뷰를 찾을 수 없습니다. reviewId: " + reviewId);
+	}
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/infrastructure/ReviewJpaRepository.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/infrastructure/ReviewJpaRepository.java
@@ -1,0 +1,19 @@
+package com.coc.modi.review.infrastructure;
+
+import com.coc.modi.review.domain.Review;
+import com.coc.modi.review.domain.ReviewStatus;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReviewJpaRepository extends JpaRepository<Review, Long> {
+
+	Optional<Review> findByIdAndStatus(Long reviewId, ReviewStatus status);
+
+	Page<Review> findBySellerIdAndStatus(Long sellerId, ReviewStatus status, Pageable pageable);
+
+	Page<Review> findByMemberIdAndStatus(Long memberId, ReviewStatus status, Pageable pageable);
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/infrastructure/ReviewRepositoryAdapter.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/infrastructure/ReviewRepositoryAdapter.java
@@ -1,0 +1,43 @@
+package com.coc.modi.review.infrastructure;
+
+import com.coc.modi.review.domain.Review;
+import com.coc.modi.review.domain.ReviewRepository;
+import com.coc.modi.review.domain.ReviewStatus;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryAdapter implements ReviewRepository {
+
+	private final ReviewJpaRepository reviewJpaRepository;
+
+	@Override
+	public Review save(Review review) {
+		return reviewJpaRepository.save(review);
+	}
+
+	@Override
+	public Optional<Review> findByIdAndStatus(Long reviewId, ReviewStatus status) {
+		
+		return reviewJpaRepository.findByIdAndStatus(reviewId, status);
+	}
+
+	@Override
+	public Page<Review> findBySellerIdAndStatus(Long sellerId, ReviewStatus status, Pageable pageable) {
+		
+		return reviewJpaRepository.findBySellerIdAndStatus(sellerId, status, pageable);
+	}
+
+	@Override
+	public Page<Review> findByMemberIdAndStatus(Long memberId, ReviewStatus status, Pageable pageable) {
+		
+		return reviewJpaRepository.findByMemberIdAndStatus(memberId, status, pageable);
+	}
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/presentation/ReviewController.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/presentation/ReviewController.java
@@ -1,0 +1,100 @@
+package com.coc.modi.review.presentation;
+
+import com.coc.modi.common.ApiResponse;
+import com.coc.modi.review.application.ReviewService;
+import com.coc.modi.review.application.dto.ReviewResponse;
+import com.coc.modi.review.application.dto.ReviewSummaryResponse;
+import com.coc.modi.review.presentation.dto.ReviewCreateRequest;
+import com.coc.modi.review.presentation.dto.ReviewUpdateRequest;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reviews")
+public class ReviewController {
+
+	private final ReviewService reviewService;
+	
+	// 판매자 리뷰 작성
+	@PostMapping
+	public ResponseEntity<ApiResponse<ReviewResponse>> createReview(Authentication authentication,
+																	@Valid @RequestBody ReviewCreateRequest request) {
+
+		Long memberId = (Long) authentication.getPrincipal();
+		ReviewResponse response = reviewService.createReview(request.toCommand(memberId));
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(response));
+	}
+	
+	// 리뷰 수정
+	@PatchMapping("/{reviewId}")
+	public ResponseEntity<ApiResponse<ReviewResponse>> updateReview(Authentication authentication,
+																	@PathVariable Long reviewId,
+																	@Valid @RequestBody ReviewUpdateRequest request) {
+
+		Long memberId = (Long) authentication.getPrincipal();
+		ReviewResponse response = reviewService.updateReview(request.toCommand(reviewId, memberId));
+
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+	
+	// 리뷰 삭제(소프트 삭제)
+	@DeleteMapping("/{reviewId}")
+	public ResponseEntity<Void> deleteReview(Authentication authentication,
+											 @PathVariable Long reviewId) {
+
+		Long memberId = (Long) authentication.getPrincipal();
+		reviewService.deleteReview(reviewId, memberId);
+
+		return ResponseEntity.noContent().build();
+	}
+	
+	// 리뷰 상세 조회
+	@GetMapping("/{reviewId}")
+	public ResponseEntity<ApiResponse<ReviewResponse>> getReview(@PathVariable Long reviewId) {
+
+		return ResponseEntity.ok(ApiResponse.ok(reviewService.getReview(reviewId)));
+	}
+	
+	// 판매자 리뷰 목록 조회
+	@GetMapping
+	public ResponseEntity<ApiResponse<List<ReviewSummaryResponse>>> getReviewsBySeller(
+			@RequestParam Long sellerId,
+			@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+		List<ReviewSummaryResponse> responses = reviewService.getReviewsBySeller(sellerId, pageable);
+
+		return ResponseEntity.ok(ApiResponse.ok(responses));
+	}
+	
+	// 내가 작성한 리뷰 목록 조회
+	@GetMapping("/me")
+	public ResponseEntity<ApiResponse<List<ReviewSummaryResponse>>> getMyReviews(Authentication authentication,
+																				 @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+		Long memberId = (Long) authentication.getPrincipal();
+		List<ReviewSummaryResponse> responses = reviewService.getReviewsByMember(memberId, pageable);
+
+		return ResponseEntity.ok(ApiResponse.ok(responses));
+	}
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/presentation/dto/ReviewCreateRequest.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/presentation/dto/ReviewCreateRequest.java
@@ -1,0 +1,21 @@
+package com.coc.modi.review.presentation.dto;
+
+import com.coc.modi.review.application.dto.CreateReviewCommand;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ReviewCreateRequest(
+		@NotNull Long rentalId,
+		@NotNull Long sellerId,
+		@NotNull @Min(1) @Max(5) Short rating,
+		@NotBlank String content
+) {
+
+	public CreateReviewCommand toCommand(Long memberId) {
+		
+		return new CreateReviewCommand(rentalId, sellerId, memberId, rating, content);
+	}
+}

--- a/modi/review-service/src/main/java/com/coc/modi/review/presentation/dto/ReviewUpdateRequest.java
+++ b/modi/review-service/src/main/java/com/coc/modi/review/presentation/dto/ReviewUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.coc.modi.review.presentation.dto;
+
+import com.coc.modi.review.application.dto.UpdateReviewCommand;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record ReviewUpdateRequest(
+		@Min(1) @Max(5) Short rating,
+		String content
+) {
+
+	public UpdateReviewCommand toCommand(Long reviewId, Long memberId) {
+		
+		return new UpdateReviewCommand(reviewId, memberId, rating, content);
+	}
+}


### PR DESCRIPTION
- ReviewService, ReviewController 기반 리뷰 CRUD API 구현 (POST/GET/PATCH/DELETE)
- 판매자 리뷰 목록 조회, 사용자 리뷰 목록 조회 기능 추가
- CreateReviewCommand, UpdateReviewCommand, ReviewResponse, ReviewSummaryResponse 등 DTO 구성 및 toCommand 패턴 적용
- Review 도메인, ReviewStatus, ReviewRepository 인터페이스 정의
- ReviewJpaRepository 및 ReviewRepositoryAdapter 구현하여 JPA 기반 인프라 계층 구성
- ReviewException, ReviewNotFoundException, ReviewAccessDeniedException 추가 및 GlobalExceptionHandler 연동
- API 명세서에 맞춰 요청/응답 스펙 반영
- review-service 전체 패키지 구조(application/domain/infrastructure/presentation) 정리 및 신규 파일 생성