### PR TITLE
fix: 예치금 취소 트랜잭션 저장 허용

### DIFF
--- a/modi/account-service/src/main/java/com/coc/modi/account/wallet/application/dto/WalletTransactionResponse.java
+++ b/modi/account-service/src/main/java/com/coc/modi/account/wallet/application/dto/WalletTransactionResponse.java
@@ -7,6 +7,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 public record WalletTransactionResponse(
+		
         WalletTransactionType txType,
         BigDecimal amount,
         BigDecimal balanceAfter,
@@ -19,7 +20,11 @@ public record WalletTransactionResponse(
 ) {
 
     public static WalletTransactionResponse from(WalletTransaction tx) {
-
+		
+		var pgDeposit = tx.getPgDeposit(); // null일 수 있음
+		
+		String pgTid = pgDeposit != null ? pgDeposit.getPgTid() : null;
+		
         return new WalletTransactionResponse(
                 tx.getTxType(),
                 tx.getAmount(),
@@ -29,7 +34,7 @@ public record WalletTransactionResponse(
                 tx.getDescription(),
                 tx.getCreatedAt(),
 				tx.getPaymentKey(),
-				tx.getPgDeposit().getPgTid()
+				pgTid
         );
     }
 }

--- a/modi/account-service/src/main/java/com/coc/modi/account/wallet/domain/WalletTransaction.java
+++ b/modi/account-service/src/main/java/com/coc/modi/account/wallet/domain/WalletTransaction.java
@@ -9,7 +9,11 @@ import java.math.BigDecimal;
 
 @Getter
 @Entity
-@Table(name = "wallet_transaction", schema = "public")
+@Table(
+		name = "wallet_transaction",
+		schema = "public",
+		uniqueConstraints = @UniqueConstraint(columnNames = {"pg_deposit_id", "tx_type"})
+)
 public class WalletTransaction extends BaseEntity {
 
     @Id
@@ -31,8 +35,8 @@ public class WalletTransaction extends BaseEntity {
 
     @Column(name = "balance_after", nullable = false, precision = 18, scale = 2)
     private BigDecimal balanceAfter;
-
-	@OneToOne(cascade = CascadeType.ALL)
+	
+	@ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pg_deposit_id")
     private PgDeposit pgDeposit;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #144 

## #️⃣ 작업 내용

- wallet_transaction 테이블에서 pg_deposit_id 단일 유니크 대신 (pg_deposit_id, tx_type) 복합 유니크로 바꿔 충전/환불을 각각 한 번씩만 저장
- WalletTransactionResponse에서는 pgDeposit이 없는 거래도 처리할 수 있도록 수정

## #️⃣ 테스트 결과

- 스웨거 테스트 완료

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요
