### PR TITLE
refactor: s3 파일 업로드 시 타입, 크기, 파일명 검증 추가

### DIFF
--- a/modi/product-service/build.gradle
+++ b/modi/product-service/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     // AWS SDK BOM 및 S3 연동
     implementation platform("software.amazon.awssdk:bom:2.28.0")
     implementation "software.amazon.awssdk:s3"
+    implementation 'org.apache.tika:tika-core:2.9.4'
 
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 

--- a/modi/product-service/src/main/java/com/coc/modi/product/product/infrastructure/S3ImageStorageAdapter.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/product/infrastructure/S3ImageStorageAdapter.java
@@ -8,16 +8,21 @@ import com.coc.modi.product.product.application.ImageStoragePort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.tika.Tika;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Component
@@ -25,6 +30,7 @@ import java.util.UUID;
 public class S3ImageStorageAdapter implements ImageStoragePort {
 	
 	private final S3Client s3Client;
+	private static final Tika TIKA = new Tika();
 	
 	@Value("${cloud.aws.s3.bucket}")
 	private String bucket;
@@ -32,55 +38,69 @@ public class S3ImageStorageAdapter implements ImageStoragePort {
 	@Value("${cloud.aws.s3.dir:}")
 	private String dir;
 	
+	@Value("${product.upload.max-bytes:5242880}")
+	private long maxBytes;
+	
+	@Value("#{${product.upload.allowed-mime:{'image/jpeg':'.jpg','image/png':'.png','image/webp':'.webp'}}}")
+	private Map<String, String> allowedMime;
+	
+	private static final Pattern DIR_PATTERN = Pattern.compile("^[a-zA-Z0-9/_-]{1,50}$");
+	
 	@Override
 	public String upload(MultipartFile file, String dirName) {
 		
-		if (file == null) {
-			throw new ProductInvalidInputException("업로드할 파일이 없습니다.");
-		}
-		if (file.isEmpty()) {
-			throw new ProductInvalidInputException("파일이 비어 있습니다.");
+		validateBeforeUpload(file);
+		
+		String safeDirName = sanitizeDirName(dirName);
+		
+		byte[] bytes = toBytes(file);
+		
+		String detectedMime = detectMime(bytes, file.getOriginalFilename());
+		String ext = allowedMime.get(detectedMime);
+		
+		if (ext == null) {
+			
+			throw new ProductInvalidInputException("허용되지 않는 파일 형식: " + detectedMime);
 		}
 		
-		String originalFilename = file.getOriginalFilename();
-		String ext = getExtension(originalFilename);
-		String key = buildKey(dirName, ext);
+		String key = buildKey(safeDirName, ext);
 		
 		try {
-			PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+			
+			PutObjectRequest put = PutObjectRequest.builder()
 					.bucket(bucket)
 					.key(key)
-					.contentType(file.getContentType())
-					.contentLength(file.getSize())
+					.contentType(detectedMime)
+					.contentLength((long)bytes.length)
 					.build();
 			
-			s3Client.putObject(
-					putObjectRequest,
-					RequestBody.fromInputStream(file.getInputStream(), file.getSize())
-			);
+			s3Client.putObject(put, RequestBody.fromBytes(bytes));
+			
+			validateAfterUpload(key, bytes.length, detectedMime);
 			
 			String url = getUrl(key);
 			
-			log.info("S3 업로드 완료: key={}, url={}", key, url);
+			log.info("S3 업로드 완료: key={}, url={}, size={}, mime={}", key, url, bytes.length, detectedMime);
 			
 			return url;
-		} catch (IOException e) {
-			throw new ProductInternalException("S3 이미지 업로드 중 오류가 발생했습니다.", e);
 		} catch (Exception e) {
-			throw new ProductInternalException("S3 이미지 업로드 중 예상치 못한 오류가 발생했습니다.", e);
+			
+			log.error("S3 업로드 실패: bucket={}, key={}, dirName={}, size={}, mime={}",
+					bucket, key, safeDirName, bytes.length, detectedMime, e);
+			
+			throw new ProductInternalException("S3 이미지 업로드 중 오류가 발생했습니다.", e);
 		}
 	}
 	
-	private String getExtension(String originalFilename) {
+	private String detectMime(byte[] bytes, String originalFilename) {
 		
-		if (originalFilename == null) {
-			return "";
+		try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes)) {
+			
+			return TIKA.detect(bais, originalFilename);
+		} catch (IOException e) {
+			
+			throw new ProductInvalidInputException("파일 MIME 판정에 실패했습니다.");
 		}
-		int idx = originalFilename.lastIndexOf('.');
-		if (idx == -1) {
-			return "";
-		}
-		return originalFilename.substring(idx);
 	}
 	
 	private String buildKey(String dirName, String ext) {
@@ -88,17 +108,11 @@ public class S3ImageStorageAdapter implements ImageStoragePort {
 		StringBuilder sb = new StringBuilder();
 		
 		if (dir != null && !dir.isBlank()) {
-			sb.append(dir);
-			if (!dir.endsWith("/")) {
-				sb.append("/");
-			}
+			sb.append(trimSlashes(dir)).append("/");
 		}
 		
 		if (dirName != null && !dirName.isBlank()) {
-			sb.append(dirName);
-			if (!dirName.endsWith("/")) {
-				sb.append("/");
-			}
+			sb.append(trimSlashes(dirName)).append("/");
 		}
 		
 		sb.append(UUID.randomUUID());
@@ -108,6 +122,112 @@ public class S3ImageStorageAdapter implements ImageStoragePort {
 		}
 		
 		return sb.toString();
+	}
+	
+	// 업로드 전 파일 검증
+	private void validateBeforeUpload(MultipartFile file) {
+		
+		if (file == null || file.isEmpty()) {
+			
+			throw new ProductInvalidInputException("업로드할 파일이 없습니다.");
+		}
+		
+		long size = file.getSize();
+		
+		if (size <= 0) {
+			throw new ProductInvalidInputException("파일 크기가 올바르지 않습니다: " + size);
+			
+		}
+		
+		if (size > maxBytes) {
+			
+			throw new ProductInvalidInputException("파일 크기 초과: " + size);
+		}
+	}
+	
+	// 업로드 후 파일 검증
+	private void validateAfterUpload(String key, long expectedSize, String expectedMime) {
+		
+		HeadObjectResponse head = s3Client.headObject(b -> b.bucket(bucket).key(key));
+		
+		long actualSize = head.contentLength();
+		String actualMime = head.contentType();
+		
+		boolean sizeOk = actualSize == expectedSize;
+		boolean mimeOk = actualMime.equalsIgnoreCase(expectedMime);
+		
+		if (!sizeOk || !mimeOk) {
+			
+			log.error("S3 업로드 검증 실패: key={}, expectedSize={}, actualSize={}, expectedMime={}, actualMime={}",
+					key, expectedSize, actualSize, expectedMime, actualMime);
+			
+			throw new ProductInternalException("S3 업로드 검증 실패: key=" + key, null);
+		}
+	}
+	
+	private String sanitizeDirName(String dirName) {
+		
+		if (dirName == null || dirName.isBlank()) {
+			
+			return null;
+		}
+		
+		String normalizedDirName = dirName.trim();
+		
+		while (normalizedDirName.startsWith("/")) {
+			
+			normalizedDirName = normalizedDirName.substring(1);
+		}
+		
+		while (normalizedDirName.endsWith("/")) {
+			
+			normalizedDirName = normalizedDirName.substring(0, normalizedDirName.length() - 1);
+		}
+		
+		if (normalizedDirName.isBlank()) {
+			
+			return null;
+		}
+		
+		if (normalizedDirName.contains("..")) {
+			
+			throw new ProductInvalidInputException("허용되지 않는 dir 값입니다.");
+		}
+		
+		if (!DIR_PATTERN.matcher(normalizedDirName).matches()) {
+			
+			throw new ProductInvalidInputException("허용되지 않는 dir 형식입니다. (영문/숫자/_-/ 만 허용)");
+		}
+		
+		return normalizedDirName;
+	}
+	
+	private byte[] toBytes(MultipartFile file) {
+		
+		try {
+			
+			return file.getBytes();
+		} catch (IOException e) {
+			
+			throw new ProductInvalidInputException("파일을 읽을 수 없습니다.");
+		}
+	}
+	
+	private String trimSlashes(String str) {
+		
+		String trimmed = str.trim();
+		
+		while (trimmed.startsWith("/")) {
+			
+			trimmed = trimmed.substring(1);
+		}
+		
+		while (trimmed.endsWith("/")) {
+			
+			trimmed = trimmed.substring(0, trimmed.length() - 1);
+		}
+		
+		return trimmed;
 	}
 	
 	private String getUrl(String key) {

--- a/modi/product-service/src/main/java/com/coc/modi/product/product/infrastructure/S3ImageStorageAdapter.java
+++ b/modi/product-service/src/main/java/com/coc/modi/product/product/infrastructure/S3ImageStorageAdapter.java
@@ -38,10 +38,10 @@ public class S3ImageStorageAdapter implements ImageStoragePort {
 	@Value("${cloud.aws.s3.dir:}")
 	private String dir;
 	
-	@Value("${product.upload.max-bytes:5242880}")
+	@Value("${product.upload.max-bytes:512000}")
 	private long maxBytes;
 	
-	@Value("#{${product.upload.allowed-mime:{'image/jpeg':'.jpg','image/png':'.png','image/webp':'.webp'}}}")
+	@Value("#{${product.upload.allowed-mime:{'image/webp':'.webp'}}}")
 	private Map<String, String> allowedMime;
 	
 	private static final Pattern DIR_PATTERN = Pattern.compile("^[a-zA-Z0-9/_-]{1,50}$");
@@ -55,12 +55,12 @@ public class S3ImageStorageAdapter implements ImageStoragePort {
 		
 		byte[] bytes = toBytes(file);
 		
-		String detectedMime = detectMime(bytes, file.getOriginalFilename());
+		String detectedMime = detectMime(bytes);
 		String ext = allowedMime.get(detectedMime);
 		
 		if (ext == null) {
 			
-			throw new ProductInvalidInputException("허용되지 않는 파일 형식: " + detectedMime);
+			throw new ProductInvalidInputException("이미지는 WebP 형식만 업로드할 수 있습니다.");
 		}
 		
 		String key = buildKey(safeDirName, ext);
@@ -92,11 +92,11 @@ public class S3ImageStorageAdapter implements ImageStoragePort {
 		}
 	}
 	
-	private String detectMime(byte[] bytes, String originalFilename) {
+	private String detectMime(byte[] bytes) {
 		
 		try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes)) {
 			
-			return TIKA.detect(bais, originalFilename);
+			return TIKA.detect(bais);
 		} catch (IOException e) {
 			
 			throw new ProductInvalidInputException("파일 MIME 판정에 실패했습니다.");


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #155 

## #️⃣ 작업 내용

> 업로드 파일 타입(MIME) 화이트리스트 적용(webp 형식만 허용)
> 파일 크기 제한 설정(500KB)
> 파일명 UUID 기반으로 정규화
> S3 업로드 전/후 검증 로직 추가

## #️⃣ 테스트 결과

> 용량 초과 시 이미지 업로드 실패
> webp를 제외한 파일 형식 이미지 업로드 실패

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요
