### PR TITLE
feature: 배송 등록·조회 API 및 추적 연동 추가

### DIFF
--- a/modi/build.gradle
+++ b/modi/build.gradle
@@ -110,7 +110,8 @@ configure([
         project(':seller-service'),
         project(':member-service'),
         project(':review-service'),
-        project(':notification-service')
+        project(':notification-service'),
+        project(':delivery-service')
 ]) {
     dependencies {
 

--- a/modi/common-security/src/main/java/com/coc/modi/common/ErrorCode.java
+++ b/modi/common-security/src/main/java/com/coc/modi/common/ErrorCode.java
@@ -27,6 +27,11 @@ public enum ErrorCode {
 	PRODUCT_INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "PRODUCT-500", "상품 처리 중 오류가 발생했습니다."),
 	PRODUCT_SEARCH_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "PRODUCT-503", "상품 검색 기능을 이용할 수 없습니다."),
 
+	DELIVERY_INVALID_INPUT(HttpStatus.BAD_REQUEST, "DELIVERY-400", "잘못된 배송 요청입니다."),
+	DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "DELIVERY-404", "배송 정보를 찾을 수 없습니다."),
+	DELIVERY_CONFLICT(HttpStatus.CONFLICT, "DELIVERY-409", "배송 요청이 현재 상태와 충돌합니다."),
+	DELIVERY_TRACKING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "DELIVERY-500", "배송 추적 처리 중 오류가 발생했습니다."),
+
 	REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW-404", "리뷰를 찾을 수 없습니다."),
 	REVIEW_FORBIDDEN(HttpStatus.FORBIDDEN, "REVIEW-403", "리뷰 접근 권한이 없습니다."),
 	

--- a/modi/delivery-service/build.gradle
+++ b/modi/delivery-service/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    // 공통 모듈 공유
+    implementation project(':common')
+
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+}

--- a/modi/delivery-service/build.gradle
+++ b/modi/delivery-service/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-    // 공통 모듈 공유
-    implementation project(':common')
 
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation "net.javacrumbs.shedlock:shedlock-spring:5.10.0"
+    implementation "net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.10.0"
 
 }

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/DeliveryServiceApplication.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/DeliveryServiceApplication.java
@@ -1,0 +1,18 @@
+package com.coc.modi.delivery;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@EnableJpaAuditing
+@EnableFeignClients(basePackages = "com.coc.modi")
+@SpringBootApplication(scanBasePackages = "com.coc.modi")
+public class DeliveryServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DeliveryServiceApplication.class, args);
+    }
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/config/SchedulerLockConfig.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/config/SchedulerLockConfig.java
@@ -1,0 +1,27 @@
+package com.coc.modi.delivery.config;
+
+import javax.sql.DataSource;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "${shedlock.default-lock-at-most-for:PT10M}")
+public class SchedulerLockConfig {
+	
+	@Bean
+	public LockProvider lockProvider(DataSource dataSource) {
+		
+		return new JdbcTemplateLockProvider(
+				JdbcTemplateLockProvider.Configuration.builder()
+						.withJdbcTemplate(new JdbcTemplate(dataSource))
+						.usingDbTime()
+						.build()
+		);
+	}
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/application/DeliveryService.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/application/DeliveryService.java
@@ -1,0 +1,61 @@
+package com.coc.modi.delivery.delivery.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.coc.modi.delivery.delivery.application.dto.DeliveryCreateCommand;
+import com.coc.modi.delivery.delivery.application.dto.DeliveryCreateResponse;
+import com.coc.modi.delivery.delivery.application.dto.DeliveryDetailResponse;
+import com.coc.modi.delivery.delivery.domain.Delivery;
+import com.coc.modi.delivery.delivery.domain.DeliveryRepository;
+import com.coc.modi.delivery.delivery.exception.DeliveryConflictException;
+import com.coc.modi.delivery.delivery.exception.DeliveryNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryService {
+	
+	private final DeliveryRepository deliveryRepository;
+	
+	// 배송 등록
+	@Transactional
+	public DeliveryCreateResponse createDelivery(DeliveryCreateCommand command) {
+		
+		boolean exists = deliveryRepository.existsByRentalItemIdAndCarrierCodeAndTrackingNumber(
+				command.rentalItemId(), command.carrierCode(), command.trackingNumber());
+		
+		if (exists) {
+			
+			throw new DeliveryConflictException(
+					"이미 등록된 배송 정보입니다. rentalItemId: " + command.rentalItemId()
+							+ ", trackingNumber: " + command.trackingNumber());
+		}
+		
+		Delivery delivery = Delivery.create(
+				command.rentalItemId(),
+				command.carrierCode(),
+				command.trackingNumber()
+		);
+		
+		Delivery saved = deliveryRepository.save(delivery);
+		
+		return new DeliveryCreateResponse(
+				saved.getId(),
+				saved.getRentalItemId(),
+				saved.getCarrierCode(),
+				saved.getTrackingNumber(),
+				saved.getStatus());
+	}
+	
+	// 배송 단건 조회
+	@Transactional(readOnly = true)
+	public DeliveryDetailResponse getDelivery(Long deliveryId) {
+		
+		Delivery delivery = deliveryRepository.findById(deliveryId)
+				.orElseThrow(() -> new DeliveryNotFoundException(deliveryId));
+		
+		return DeliveryDetailResponse.from(delivery);
+	}
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/application/DeliveryStatusMapper.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/application/DeliveryStatusMapper.java
@@ -1,0 +1,27 @@
+package com.coc.modi.delivery.delivery.application;
+
+import org.springframework.stereotype.Component;
+
+import com.coc.modi.delivery.delivery.domain.DeliveryStatus;
+import com.coc.modi.delivery.delivery.infrastructure.TrackingResult;
+
+@Component
+public class DeliveryStatusMapper {
+	
+	public DeliveryStatus map(TrackingResult result) {
+		
+		if (result.delivered()) {
+			return DeliveryStatus.DELIVERED;
+		}
+		
+		return switch (result.rawStatus()) {
+			case "AT_PICKUP" -> DeliveryStatus.PICKED_UP;
+			case "IN_TRANSIT" -> DeliveryStatus.IN_TRANSIT;
+			case "OUT_FOR_DELIVERY", "AVAILABLE_FOR_PICKU" -> DeliveryStatus.OUT_FOR_DELIVERY;
+			case "DELIVERED" -> DeliveryStatus.DELIVERED;
+			case "ATTEMPT_FAIL", "EXCEPTION" -> DeliveryStatus.EXCEPTION;
+			case "CANCELLED" -> DeliveryStatus.CANCELLED;
+			default -> DeliveryStatus.REGISTERED;
+		};
+	}
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/application/DeliveryStatusMapper.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/application/DeliveryStatusMapper.java
@@ -10,6 +10,10 @@ public class DeliveryStatusMapper {
 	
 	public DeliveryStatus map(TrackingResult result) {
 		
+		if (result == null) {
+			return DeliveryStatus.REGISTERED;
+		}
+		
 		if (result.delivered()) {
 			return DeliveryStatus.DELIVERED;
 		}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/application/dto/DeliveryCreateCommand.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/application/dto/DeliveryCreateCommand.java
@@ -1,0 +1,18 @@
+package com.coc.modi.delivery.delivery.application.dto;
+
+import com.coc.modi.delivery.delivery.presentation.dto.DeliveryCreateRequest;
+
+public record DeliveryCreateCommand(
+		Long rentalItemId,
+		String carrierCode,
+		String trackingNumber
+) {
+	
+	public static DeliveryCreateCommand toCommand(DeliveryCreateRequest request) {
+		
+		return new DeliveryCreateCommand(
+				request.rentalItemId(),
+				request.carrierCode(),
+				request.trackingNumber());
+	}
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/application/dto/DeliveryCreateResponse.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/application/dto/DeliveryCreateResponse.java
@@ -1,0 +1,12 @@
+package com.coc.modi.delivery.delivery.application.dto;
+
+import com.coc.modi.delivery.delivery.domain.DeliveryStatus;
+
+public record DeliveryCreateResponse(
+		Long id,
+		Long rentalItemId,
+		String carrierCode,
+		String trackingNumber,
+		DeliveryStatus status
+) {
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/application/dto/DeliveryCreateResponse.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/application/dto/DeliveryCreateResponse.java
@@ -3,7 +3,7 @@ package com.coc.modi.delivery.delivery.application.dto;
 import com.coc.modi.delivery.delivery.domain.DeliveryStatus;
 
 public record DeliveryCreateResponse(
-		Long id,
+		Long deliveryId,
 		Long rentalItemId,
 		String carrierCode,
 		String trackingNumber,

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/application/dto/DeliveryDetailResponse.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/application/dto/DeliveryDetailResponse.java
@@ -6,7 +6,7 @@ import com.coc.modi.delivery.delivery.domain.DeliveryStatus;
 import java.time.LocalDateTime;
 
 public record DeliveryDetailResponse(
-		Long id,
+		Long deliveryId,
 		Long rentalItemId,
 		String carrierCode,
 		String trackingNumber,

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/application/dto/DeliveryDetailResponse.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/application/dto/DeliveryDetailResponse.java
@@ -1,0 +1,31 @@
+package com.coc.modi.delivery.delivery.application.dto;
+
+import com.coc.modi.delivery.delivery.domain.Delivery;
+import com.coc.modi.delivery.delivery.domain.DeliveryStatus;
+
+import java.time.LocalDateTime;
+
+public record DeliveryDetailResponse(
+		Long id,
+		Long rentalItemId,
+		String carrierCode,
+		String trackingNumber,
+		DeliveryStatus status,
+		String statusRaw,
+		LocalDateTime createdAt,
+		LocalDateTime updatedAt
+) {
+	
+	public static DeliveryDetailResponse from(Delivery delivery) {
+		
+		return new DeliveryDetailResponse(
+				delivery.getId(),
+				delivery.getRentalItemId(),
+				delivery.getCarrierCode(),
+				delivery.getTrackingNumber(),
+				delivery.getStatus(),
+				delivery.getStatusRaw(),
+				delivery.getCreatedAt(),
+				delivery.getUpdatedAt());
+	}
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/domain/Delivery.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/domain/Delivery.java
@@ -1,0 +1,74 @@
+package com.coc.modi.delivery.delivery.domain;
+
+import java.time.LocalDateTime;
+
+import com.coc.modi.common.BaseEntity;
+import com.coc.modi.delivery.delivery.infrastructure.TrackingResult;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "delivery", schema = "public")
+public class Delivery extends BaseEntity {
+	
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	@Column(name = "rental_item_id", nullable = false)
+	private Long rentalItemId;
+	
+	@Column(name = "carrier_code", length = 30, nullable = false)
+	private String carrierCode;
+	
+	@Column(name = "tracking_number", length = 50, nullable = false)
+	private String trackingNumber;
+	
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", length = 20, nullable = false)
+	private DeliveryStatus status;
+	
+	@Column(name = "status_raw", length = 50)
+	private String statusRaw;
+	
+	@Column(name = "last_tracked_at")
+	private LocalDateTime lastTrackedAt;
+	
+	protected Delivery() {
+	
+	}
+	
+	private Delivery(Long rentalItemId,
+					 String carrierCode,
+					 String trackingNumber,
+					 DeliveryStatus status,
+					 String statusRaw) {
+		
+		this.rentalItemId = rentalItemId;
+		this.carrierCode = carrierCode;
+		this.trackingNumber = trackingNumber;
+		this.status = status != null ? status : DeliveryStatus.REGISTERED;
+		this.statusRaw = statusRaw;
+		this.lastTrackedAt = null;
+	}
+	
+	public static Delivery create(Long rentalItemId,
+								  String carrierCode,
+								  String trackingNumber) {
+		
+		return new Delivery(rentalItemId, carrierCode, trackingNumber, null, null);
+	}
+	
+	public void applyTrackingResult(DeliveryStatus status, TrackingResult result) {
+		
+		this.status = status;
+		this.statusRaw = (result != null) ? result.rawStatus() : null;
+	}
+	
+	public void markTrackedNow() {
+		
+		this.lastTrackedAt = LocalDateTime.now();
+	}
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/domain/DeliveryRepository.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/domain/DeliveryRepository.java
@@ -1,0 +1,18 @@
+package com.coc.modi.delivery.delivery.domain;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DeliveryRepository {
+	
+	Delivery save(Delivery delivery);
+	
+	boolean existsByRentalItemIdAndCarrierCodeAndTrackingNumber(Long rentalItemId,
+																String carrierCode,
+																String trackingNumber);
+	
+	Optional<Delivery> findById(Long id);
+	
+	List<Delivery> findTargetsForTrackingWithSkipLocked(int intervalMinutes, int limit);
+	
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/domain/DeliveryStatus.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/domain/DeliveryStatus.java
@@ -1,0 +1,12 @@
+package com.coc.modi.delivery.delivery.domain;
+
+public enum DeliveryStatus {
+	
+	REGISTERED,          // 송장 등록
+	PICKED_UP,           // 집하
+	IN_TRANSIT,          // 이동중
+	OUT_FOR_DELIVERY,    // 배송출발
+	DELIVERED,           // 배송 완료
+	EXCEPTION,           // 예외(주소불명/분실/반송 등)
+	CANCELLED            // 취소/배송 중단
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/exception/DeliveryConflictException.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/exception/DeliveryConflictException.java
@@ -1,0 +1,11 @@
+package com.coc.modi.delivery.delivery.exception;
+
+import com.coc.modi.common.ErrorCode;
+
+public class DeliveryConflictException extends DeliveryException {
+	
+	public DeliveryConflictException(String message) {
+		
+		super(ErrorCode.DELIVERY_CONFLICT, message);
+	}
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/exception/DeliveryException.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/exception/DeliveryException.java
@@ -1,0 +1,17 @@
+package com.coc.modi.delivery.delivery.exception;
+
+import com.coc.modi.common.BaseException;
+import com.coc.modi.common.ErrorCode;
+
+public class DeliveryException extends BaseException {
+	
+	public DeliveryException(ErrorCode errorCode) {
+		
+		super(errorCode);
+	}
+	
+	public DeliveryException(ErrorCode errorCode, String message) {
+		
+		super(errorCode, message);
+	}
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/exception/DeliveryNotFoundException.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/exception/DeliveryNotFoundException.java
@@ -1,0 +1,11 @@
+package com.coc.modi.delivery.delivery.exception;
+
+import com.coc.modi.common.ErrorCode;
+
+public class DeliveryNotFoundException extends DeliveryException {
+	
+	public DeliveryNotFoundException(Long deliveryId) {
+		
+		super(ErrorCode.DELIVERY_NOT_FOUND, "배송 정보를 찾을 수 없습니다. deliveryId: " + deliveryId);
+	}
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/exception/DeliveryTrackingClientException.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/exception/DeliveryTrackingClientException.java
@@ -1,0 +1,11 @@
+package com.coc.modi.delivery.delivery.exception;
+
+import com.coc.modi.common.ErrorCode;
+
+public class DeliveryTrackingClientException extends DeliveryException {
+	
+	public DeliveryTrackingClientException(String message) {
+		
+		super(ErrorCode.DELIVERY_TRACKING_ERROR, message);
+	}
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/infrastructure/CarrierTrackingClient.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/infrastructure/CarrierTrackingClient.java
@@ -1,0 +1,119 @@
+package com.coc.modi.delivery.delivery.infrastructure;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.coc.modi.delivery.delivery.infrastructure.dto.TrackerDeliveryResponse;
+import com.coc.modi.delivery.delivery.exception.DeliveryTrackingClientException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class CarrierTrackingClient {
+	
+	private final WebClient webClient;
+	private final String authorizationValue;
+	
+	public CarrierTrackingClient(WebClient.Builder builder,
+								 @Value("${tracker-delivery.endpoint:https://apis.tracker.delivery/graphql}") String endpoint,
+								 @Value("${tracker-delivery.client-id}") String clientId,
+								 @Value("${tracker-delivery.client-secret}") String clientSecret) {
+		
+		this.webClient = builder.baseUrl(endpoint)
+				.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+				.build();
+		
+		this.authorizationValue = "TRACKQL-API-KEY " + clientId + ":" + clientSecret;
+	}
+	
+	public TrackingResult track(String carrierCode, String trackingNumber) {
+		
+		carrierCode = carrierCode.trim();
+		trackingNumber = trackingNumber.replaceAll("[^0-9A-Za-z]", "");
+		
+		String query = """
+					query track($carrierId: ID!, $trackingNumber: String!) {
+						track(carrierId: $carrierId, trackingNumber: $trackingNumber) {
+							trackingNumber
+							lastEvent {
+								description
+								status { code name }
+							}
+						}
+					}
+				""";
+		
+		Map<String, Object> body = Map.of("query", query, "variables", Map.of("carrierId", carrierCode, "trackingNumber", trackingNumber));
+		
+		TrackerDeliveryResponse response;
+		try {
+			
+			response = webClient.post()
+					.header(HttpHeaders.AUTHORIZATION, authorizationValue)
+					.bodyValue(body)
+					.retrieve()
+					.bodyToMono(TrackerDeliveryResponse.class)
+					.timeout(Duration.ofSeconds(10))
+					.block();
+		} catch (Exception e) {
+			
+			log.warn("[배송추적][외부연동] tracker.delivery 호출 실패 (일시적 오류) carrierCode={} trackingNumber={} 오류={}", carrierCode, trackingNumber, e.toString());
+			return new TrackingResult("UNKNOWN", "TRANSIENT_NETWORK_ERROR", false);
+		}
+		
+		if (response == null) {
+			
+			throw new DeliveryTrackingClientException("배송 추적 API 응답이 비어있습니다.");
+		}
+		
+		if (response.errors() != null && !response.errors().isEmpty()) {
+			
+			String msg = response.errors().get(0).message();
+			
+			log.warn("[배송추적][외부연동] tracker.delivery 오류 응답 carrierCode={} trackingNumber={} errors={}", carrierCode, trackingNumber, response.errors());
+			
+			if (isTransientError(msg)) {
+				return new TrackingResult("UNKNOWN", "TRANSIENT_ERROR: " + msg, false);
+			}
+			
+			throw new DeliveryTrackingClientException("배송 추적 API 오류: " + msg);
+		}
+		
+		if (response.data() == null || response.data().track() == null) {
+			
+			log.info("[배송추적][외부연동] 배송 조회 불가 또는 미집하 상태 carrierCode={} trackingNumber={}", carrierCode, trackingNumber);
+			
+			return new TrackingResult("UNKNOWN", "TRACK_NOT_FOUND_OR_NOT_READY", false);
+		}
+		
+		var lastEvent = response.data().track().lastEvent();
+		
+		if (lastEvent == null || lastEvent.status() == null || lastEvent.status().code() == null) {
+			
+			return new TrackingResult("UNKNOWN", null, false);
+		}
+		
+		String code = lastEvent.status().code();
+		boolean delivered = "DELIVERED".equals(code);
+		String desc = lastEvent.description();
+		
+		return new TrackingResult(code, desc, delivered);
+	}
+	
+	private boolean isTransientError(String msg) {
+		
+		if (msg == null) {
+			return false;
+		}
+		String m = msg.toLowerCase();
+		return m.contains("try again") || m.contains("internal error") || m.contains("temporar")
+				|| m.contains("timeout") || m.contains("rate") || m.contains("too many");
+	}
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/infrastructure/CarrierTrackingClient.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/infrastructure/CarrierTrackingClient.java
@@ -2,12 +2,16 @@ package com.coc.modi.delivery.delivery.infrastructure;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import com.coc.modi.delivery.delivery.infrastructure.dto.TrackerDeliveryResponse;
 import com.coc.modi.delivery.delivery.exception.DeliveryTrackingClientException;
@@ -62,15 +66,41 @@ public class CarrierTrackingClient {
 					.bodyToMono(TrackerDeliveryResponse.class)
 					.timeout(Duration.ofSeconds(10))
 					.block();
+		} catch (WebClientResponseException e) {
+			
+			HttpStatusCode status = e.getStatusCode();
+			
+			if (isTransientHttpStatus(status)) {
+				
+				log.warn("[배송추적][외부연동] tracker.delivery HTTP 오류 (일시적) carrierCode={} trackingNumber={} status={} 오류={}",
+						carrierCode, trackingNumber, status, e.toString());
+				return new TrackingResult("UNKNOWN", "TRANSIENT_HTTP_ERROR: " + status, false);
+			}
+			
+			throw new DeliveryTrackingClientException("[배송추적][외부연동] API HTTP 오류: status=" + status
+					+ " body=" + e.getResponseBodyAsString());
+		} catch (WebClientRequestException e) {
+			
+			log.warn("[배송추적][외부연동] tracker.delivery 네트워크 오류 (일시적) carrierCode={} trackingNumber={} 오류={}",
+					carrierCode, trackingNumber, e.toString());
+			
+			return new TrackingResult("UNKNOWN", "TRANSIENT_NETWORK_ERROR", false);
 		} catch (Exception e) {
 			
-			log.warn("[배송추적][외부연동] tracker.delivery 호출 실패 (일시적 오류) carrierCode={} trackingNumber={} 오류={}", carrierCode, trackingNumber, e.toString());
-			return new TrackingResult("UNKNOWN", "TRANSIENT_NETWORK_ERROR", false);
+			if (isTimeoutException(e)) {
+				
+				log.warn("[배송추적][외부연동] tracker.delivery 타임아웃 (일시적) carrierCode={} trackingNumber={} 오류={}",
+						carrierCode, trackingNumber, e.toString());
+				
+				return new TrackingResult("UNKNOWN", "TRANSIENT_TIMEOUT", false);
+			}
+			
+			throw new DeliveryTrackingClientException("[배송추적][외부연동] API 알 수 없는 오류: " + e);
 		}
 		
 		if (response == null) {
 			
-			throw new DeliveryTrackingClientException("배송 추적 API 응답이 비어있습니다.");
+			throw new DeliveryTrackingClientException("[배송추적][외부연동] API 응답이 비어있습니다.");
 		}
 		
 		if (response.errors() != null && !response.errors().isEmpty()) {
@@ -115,5 +145,25 @@ public class CarrierTrackingClient {
 		String m = msg.toLowerCase();
 		return m.contains("try again") || m.contains("internal error") || m.contains("temporar")
 				|| m.contains("timeout") || m.contains("rate") || m.contains("too many");
+	}
+
+	private boolean isTransientHttpStatus(HttpStatusCode status) {
+		
+		if (status == null) {
+			return false;
+		}
+		return status.is5xxServerError() || status.value() == 408 || status.value() == 429;
+	}
+
+	private boolean isTimeoutException(Throwable e) {
+		
+		Throwable current = e;
+		while (current != null) {
+			if (current instanceof TimeoutException) {
+				return true;
+			}
+			current = current.getCause();
+		}
+		return false;
 	}
 }

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/infrastructure/DeliveryJpaRepository.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/infrastructure/DeliveryJpaRepository.java
@@ -1,0 +1,32 @@
+package com.coc.modi.delivery.delivery.infrastructure;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.coc.modi.delivery.delivery.domain.Delivery;
+
+public interface DeliveryJpaRepository extends JpaRepository<Delivery, Long> {
+	
+	boolean existsByRentalItemIdAndCarrierCodeAndTrackingNumber(Long rentalItemId,
+																String carrierCode,
+																String trackingNumber);
+	
+	@Query(value = """
+			SELECT *
+				FROM public.delivery d
+			WHERE d.status not in('DELIVERED', 'CANCELLED')
+				AND (d.last_tracked_at is null
+					OR d.last_tracked_at < (now() - make_interval(mins => :intervalMinutes)))
+			ORDER BY d.last_tracked_at nulls first, d.id
+			FOR update skip locked
+			LIMIT :limit
+			""", nativeQuery = true)
+	List<Delivery> findTargetsForTrackingWithSkipLocked(
+			@Param("limit") int limit,
+			@Param("intervalMinutes") int intervalMinutes
+	);
+}
+

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/infrastructure/DeliveryRepositoryAdapter.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/infrastructure/DeliveryRepositoryAdapter.java
@@ -1,0 +1,44 @@
+package com.coc.modi.delivery.delivery.infrastructure;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.coc.modi.delivery.delivery.domain.Delivery;
+import com.coc.modi.delivery.delivery.domain.DeliveryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class DeliveryRepositoryAdapter implements DeliveryRepository {
+	
+	private final DeliveryJpaRepository deliveryJpaRepository;
+	
+	@Override
+	public Delivery save(Delivery delivery) {
+		
+		return deliveryJpaRepository.save(delivery);
+	}
+	
+	@Override
+	public boolean existsByRentalItemIdAndCarrierCodeAndTrackingNumber(Long rentalItemId,
+																	   String carrierCode,
+																	   String trackingNumber) {
+		
+		return deliveryJpaRepository.existsByRentalItemIdAndCarrierCodeAndTrackingNumber(
+				rentalItemId, carrierCode, trackingNumber);
+	}
+	
+	@Override
+	public java.util.Optional<Delivery> findById(Long id) {
+		
+		return deliveryJpaRepository.findById(id);
+	}
+	
+	@Override
+	public List<Delivery> findTargetsForTrackingWithSkipLocked(int intervalMinutes, int limit) {
+		
+		return deliveryJpaRepository.findTargetsForTrackingWithSkipLocked(intervalMinutes, limit);
+	}
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/infrastructure/TrackingResult.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/infrastructure/TrackingResult.java
@@ -1,0 +1,8 @@
+package com.coc.modi.delivery.delivery.infrastructure;
+
+public record TrackingResult(
+		String rawStatus,
+		String description,
+		boolean delivered
+) {
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/infrastructure/dto/TrackerDeliveryResponse.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/infrastructure/dto/TrackerDeliveryResponse.java
@@ -1,0 +1,36 @@
+package com.coc.modi.delivery.delivery.infrastructure.dto;
+
+import java.util.List;
+
+public record TrackerDeliveryResponse(
+		Data data,
+		List<ApiError> errors
+) {
+	public record Data(
+			Track track
+	) {
+	}
+	
+	public record Track(
+			String trackingNumber,
+			LastEvent lastEvent
+	) {
+	}
+	
+	public record LastEvent(
+			String description,
+			Status status
+	) {
+	}
+	
+	public record Status(
+			String code,    // IN_TRANSIT, OUT_FOR_DELIVERY, DELIVERED ...
+			String name     // 배송중, 배송출발, 배송완료 ...
+	) {
+	}
+	
+	public record ApiError(
+			String message
+	) {
+	}
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/presentation/DeliveryController.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/presentation/DeliveryController.java
@@ -1,0 +1,44 @@
+package com.coc.modi.delivery.delivery.presentation;
+
+import com.coc.modi.common.ApiResponse;
+import com.coc.modi.delivery.delivery.application.DeliveryService;
+import com.coc.modi.delivery.delivery.application.dto.DeliveryCreateCommand;
+import com.coc.modi.delivery.delivery.application.dto.DeliveryCreateResponse;
+import com.coc.modi.delivery.delivery.application.dto.DeliveryDetailResponse;
+import com.coc.modi.delivery.delivery.presentation.dto.DeliveryCreateRequest;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/deliveries")
+public class DeliveryController {
+	
+	private final DeliveryService deliveryService;
+	
+	// 배송 등록
+	@PostMapping
+	public ResponseEntity<ApiResponse<DeliveryCreateResponse>> createDelivery(@Valid @RequestBody DeliveryCreateRequest request) {
+		
+		DeliveryCreateCommand command = DeliveryCreateCommand.toCommand(request);
+		
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(deliveryService.createDelivery(command)));
+	}
+	
+	// 배송 단건 조회
+	@GetMapping("/{deliveryId}")
+	public ResponseEntity<ApiResponse<DeliveryDetailResponse>> getDelivery(@PathVariable("deliveryId") Long deliveryId) {
+		
+		return ResponseEntity.ok(ApiResponse.ok(deliveryService.getDelivery(deliveryId)));
+	}
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/presentation/dto/DeliveryCreateRequest.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/presentation/dto/DeliveryCreateRequest.java
@@ -1,0 +1,20 @@
+package com.coc.modi.delivery.delivery.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record DeliveryCreateRequest(
+		
+		@NotNull(message = "rentalItemId는 필수입니다.")
+		Long rentalItemId,
+		
+		@NotBlank(message = "carrierCode는 필수입니다.")
+		@Size(max = 30, message = "carrierCode는 30자를 넘을 수 없습니다.")
+		String carrierCode,
+		
+		@NotBlank(message = "trackingNumber는 필수입니다.")
+		@Size(max = 50, message = "trackingNumber는 50자를 넘을 수 없습니다.")
+		String trackingNumber
+) {
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/scheduler/DeliveryTrackingJob.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/scheduler/DeliveryTrackingJob.java
@@ -1,0 +1,29 @@
+package com.coc.modi.delivery.delivery.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeliveryTrackingJob {
+	
+	private final DeliveryTrackingService deliveryTrackingService;
+	
+	@Scheduled(fixedDelayString = "PT5M")
+	public void run() {
+		
+		int limit = 200;
+		int intervalMinutes = 10;
+		
+		log.info("[배송추적] 시작 limit={} intervalMinutes={}", limit, intervalMinutes);
+		
+		deliveryTrackingService.claimAndProcess(limit, intervalMinutes);
+		
+		log.info("[배송추적] 종료 limit: {}, intervalMinutes: {}", limit, intervalMinutes);
+	}
+	
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/scheduler/DeliveryTrackingJob.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/scheduler/DeliveryTrackingJob.java
@@ -1,7 +1,10 @@
 package com.coc.modi.delivery.delivery.scheduler;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,13 +14,21 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class DeliveryTrackingJob {
 	
+	@Value("${delivery.tracking.limit:200}")
+	private int limit;
+	
+	@Value("${delivery.tracking.intervalMinutes:10}")
+	private int intervalMinutes;
+	
 	private final DeliveryTrackingService deliveryTrackingService;
 	
-	@Scheduled(fixedDelayString = "PT5M")
+	@Scheduled(fixedDelayString = "${delivery.tracking.fixed-delay:PT5M}")
+	@SchedulerLock(
+			name = "deliveryTrackingJob",
+			lockAtMostFor = "${delivery.tracking.lock-at-most-for:PT5M}",
+			lockAtLeastFor = "${delivery.tracking.lock-at-least-for:PT30S}"
+	)
 	public void run() {
-		
-		int limit = 200;
-		int intervalMinutes = 10;
 		
 		log.info("[배송추적] 시작 limit={} intervalMinutes={}", limit, intervalMinutes);
 		

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/scheduler/DeliveryTrackingService.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/delivery/scheduler/DeliveryTrackingService.java
@@ -1,0 +1,63 @@
+package com.coc.modi.delivery.delivery.scheduler;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.coc.modi.delivery.delivery.application.DeliveryStatusMapper;
+import com.coc.modi.delivery.delivery.domain.Delivery;
+import com.coc.modi.delivery.delivery.domain.DeliveryRepository;
+import com.coc.modi.delivery.delivery.domain.DeliveryStatus;
+import com.coc.modi.delivery.delivery.infrastructure.CarrierTrackingClient;
+import com.coc.modi.delivery.delivery.infrastructure.TrackingResult;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeliveryTrackingService {
+	
+	private final DeliveryRepository deliveryRepository;
+	private final CarrierTrackingClient carrierTrackingClient;
+	private final DeliveryStatusMapper deliveryStatusMapper;
+	
+	@Transactional
+	public void claimAndProcess(int limit, int intervalMinutes) {
+		
+		List<Delivery> targets = deliveryRepository.findTargetsForTrackingWithSkipLocked(limit, intervalMinutes);
+		int failCount = 0;
+		
+		log.info("[배송추적] 대상 건수: {}", targets.size());
+		
+		for (Delivery d : targets) {
+			
+			try {
+				
+				log.info("[배송추적] 처리 시작. deliveryId: {}", d.getId());
+				
+				TrackingResult result = carrierTrackingClient.track(d.getCarrierCode(), d.getTrackingNumber());
+				DeliveryStatus mapped = deliveryStatusMapper.map(result);
+				
+				d.applyTrackingResult(mapped, result);
+				d.markTrackedNow();
+				
+				log.info("[배송추적] 처리 완료. deliveryId: {}, status: {}", d.getId(), mapped);
+				
+			} catch (Exception e) {
+				
+				d.markTrackedNow();
+				failCount++;
+				log.warn("[배송추적] 처리 실패. deliveryId: {}, carrierCode: {}, trackingNumber: {}",
+						d.getId(), d.getCarrierCode(), d.getTrackingNumber(), e);
+			}
+		}
+		
+		if (failCount > 0) {
+			
+			log.warn("[배송추적] 처리 실패 건수: {}", failCount);
+		}
+	}
+}

--- a/modi/delivery-service/src/main/java/com/coc/modi/delivery/exception/GlobalExceptionHandler.java
+++ b/modi/delivery-service/src/main/java/com/coc/modi/delivery/exception/GlobalExceptionHandler.java
@@ -1,0 +1,79 @@
+package com.coc.modi.delivery.exception;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.coc.modi.common.ApiResponse;
+import com.coc.modi.common.BaseException;
+import com.coc.modi.common.ErrorCode;
+import com.coc.modi.delivery.delivery.exception.DeliveryException;
+
+@RestControllerAdvice(basePackages = "com.coc.modi.delivery")
+public class GlobalExceptionHandler {
+	
+	private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+	
+	@ExceptionHandler(DeliveryException.class)
+	public ResponseEntity<ApiResponse<?>> handleBaseException(DeliveryException ex) {
+		
+		log.warn("Product exception: code={}, message={}", ex.getErrorCode().getCode(), ex.getDetailMessage());
+		return buildResponse(ex.getErrorCode(), ex.getDetailMessage());
+	}
+	
+	@ExceptionHandler(BaseException.class)
+	public ResponseEntity<ApiResponse<?>> handleBaseException(BaseException ex) {
+		
+		log.warn("Business exception: code={}, message={}", ex.getErrorCode().getCode(), ex.getDetailMessage());
+		return buildResponse(ex.getErrorCode(), ex.getDetailMessage());
+	}
+	
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ApiResponse<?>> handleIllegalArgument(IllegalArgumentException ex) {
+		
+		log.warn("Illegal argument: {}", ex.getMessage());
+		return buildResponse(ErrorCode.INVALID_INPUT, ex.getMessage());
+	}
+	
+	@ExceptionHandler(IllegalStateException.class)
+	public ResponseEntity<ApiResponse<?>> handleIllegalState(IllegalStateException ex) {
+		
+		log.warn("Illegal state: {}", ex.getMessage());
+		return buildResponse(ErrorCode.CONFLICT, ex.getMessage());
+	}
+	
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ApiResponse<?>> handleValidation(MethodArgumentNotValidException ex) {
+		
+		String message = Optional.of(ex.getBindingResult())
+				.map(bindingResult -> bindingResult.getFieldErrors()
+						.stream()
+						.map(error -> error.getField() + ": " + error.getDefaultMessage())
+						.collect(Collectors.joining(", ")))
+				.filter(str -> !str.isBlank())
+				.orElse(ErrorCode.INVALID_INPUT.getDefaultMessage());
+		
+		log.warn("Validation error: {}", message);
+		return buildResponse(ErrorCode.INVALID_INPUT, message);
+	}
+	
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ApiResponse<?>> handleUnexpected(Exception ex) {
+		
+		log.error("Unexpected error", ex);
+		return buildResponse(ErrorCode.INTERNAL_ERROR, ErrorCode.INTERNAL_ERROR.getDefaultMessage());
+	}
+	
+	private ResponseEntity<ApiResponse<?>> buildResponse(ErrorCode errorCode, String message) {
+		
+		return ResponseEntity
+				.status(errorCode.getStatus())
+				.body(ApiResponse.error(errorCode, message));
+	}
+}

--- a/modi/settings.gradle
+++ b/modi/settings.gradle
@@ -13,6 +13,7 @@ include(
         'member-service',
         'review-service',
         'notification-service',
+        'delivery-service',
         'modi-gateway',
         'modi-discovery',
         'modi-config'


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #160 

## #️⃣ 작업 내용

> - delivery-service 모듈 신규 생성 및 설정 반영
> - 배송 엔티티/리포지토리 포트-어댑터 구조 구성
> - 배송 등록·단건 조회 API와 요청/응답 DTO 신규 생성
> - 배송 추적 배치 스케줄러 신규 생성 및 실행 흐름 구성

## #️⃣ 테스트 결과

> 배송 등록/조회 가능
> 5분 단위로 배치 실행
> 10분 단위로 배송 추적(배송 완료/취소 제외)

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요
