### PR TITLE
k3d 로컬 이미지 빌드/임포트 보강 및 Kafka 단일 브로커 설정

### DIFF
--- a/modi/k8s/base/kafka.yaml
+++ b/modi/k8s/base/kafka.yaml
@@ -54,8 +54,14 @@ spec:
             - name: controller
               containerPort: 9093
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: KAFKA_NODE_ID
-              value: "0"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
             - name: KAFKA_PROCESS_ROLES
               value: "controller,broker"
             - name: KAFKA_CONTROLLER_QUORUM_VOTERS
@@ -63,7 +69,7 @@ spec:
             - name: KAFKA_LISTENERS
               value: "PLAINTEXT://:9092,CONTROLLER://:9093"
             - name: KAFKA_ADVERTISED_LISTENERS
-              value: "PLAINTEXT://kafka:9092"
+              value: "PLAINTEXT://$(POD_NAME).kafka-headless:9092"
             - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
               value: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
             - name: KAFKA_CONTROLLER_LISTENER_NAMES
@@ -77,6 +83,10 @@ spec:
             - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
               value: "1"
             - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: KAFKA_MIN_INSYNC_REPLICAS
+              value: "1"
+            - name: KAFKA_DEFAULT_REPLICATION_FACTOR
               value: "1"
             - name: KAFKA_KRAFT_CLUSTER_ID
               value: "b8Qd7mMNSCqvQ8Gx8p6mVg"

--- a/modi/k8s/scripts/k3s-up.sh
+++ b/modi/k8s/scripts/k3s-up.sh
@@ -55,6 +55,10 @@ if [ "${K3D_IMPORT_IMAGES}" = "true" ]; then
 
   echo "Building local images with docker compose..." >&2
   docker compose -f "${ROOT_DIR}/docker-compose.yml" build
+  echo "Building additional local images..." >&2
+  docker build -f "${ROOT_DIR}/delivery-service/Dockerfile" -t modi/delivery-service:local "${ROOT_DIR}"
+  docker build -f "${ROOT_DIR}/notification-service/Dockerfile" -t modi/notification-service:local "${ROOT_DIR}"
+  docker build -f "${ROOT_DIR}/review-service/Dockerfile" -t modi/review-service:local "${ROOT_DIR}"
 
   IMAGES=(
     modi/modi-discovery:local
@@ -65,6 +69,9 @@ if [ "${K3D_IMPORT_IMAGES}" = "true" ]; then
     modi/rental-service:local
     modi/seller-service:local
     modi/member-service:local
+    modi/delivery-service:local
+    modi/notification-service:local
+    modi/review-service:local
   )
 
   echo "Importing images into k3d cluster '${K3D_CLUSTER_NAME}'..." >&2

--- a/modi/notification-service/Dockerfile
+++ b/modi/notification-service/Dockerfile
@@ -3,7 +3,7 @@ FROM eclipse-temurin:17-jdk AS builder
 WORKDIR /app
 
 # 0) Gradle이 쓸 캐시 경로(지금 이미지에서 HOME=/root 인 경우가 많음)
-ARG MODULE=seller-service
+ARG MODULE=notification-service
 ENV GRADLE_USER_HOME=/root/.gradle-${MODULE}
 
 # 1) 캐시가 잘 먹게 빌드 스크립트/래퍼 먼저 복사


### PR DESCRIPTION
 - 요약: k3d 환경에서 로컬 이미지 누락으로 발생하던 ImagePullBackOff를 방지하고, Kafka를 단일 브로커로 줄여 리소스 사용량을 낮춤.

  - 변경 사항:
      - k8s/scripts/k3s-up.sh에 delivery/notification/review 이미지 빌드 및 import 추가
      - notification-service/Dockerfile의 MODULE 기본값 수정
      - k8s/base/kafka.yaml을 1 replica 및 단일 브로커에 맞게 replication/ISR 설정 조정
  - 테스트: 미실행(로컬 k3d에서 kubectl apply -k k8s/overlays/k3s로 적용 확인)