### PR TITLE
판매자 등록 승인/거절 흐름 정리

### DIFF
--- a/modi/common-kafka/src/main/java/com/coc/modi/kafka/event/SellerRegistrationApprovedEvent.java
+++ b/modi/common-kafka/src/main/java/com/coc/modi/kafka/event/SellerRegistrationApprovedEvent.java
@@ -3,20 +3,20 @@ package com.coc.modi.kafka.event;
 import java.time.Instant;
 import java.util.UUID;
 
-public record SellerApprovedEvent(
+public record SellerRegistrationApprovedEvent(
 		String eventId,
 		Instant occurredAt,
-		Long sellerId,
+		Long registrationId,
 		Long memberId,
 		String email
 ) {
 
-	public static SellerApprovedEvent of(Long sellerId, Long memberId, String email) {
+	public static SellerRegistrationApprovedEvent of(Long registrationId, Long memberId, String email) {
 
-		return new SellerApprovedEvent(
+		return new SellerRegistrationApprovedEvent(
 				UUID.randomUUID().toString(),
 				Instant.now(),
-				sellerId,
+				registrationId,
 				memberId,
 				email
 		);

--- a/modi/common-kafka/src/main/java/com/coc/modi/kafka/event/SellerRegistrationRejectedEvent.java
+++ b/modi/common-kafka/src/main/java/com/coc/modi/kafka/event/SellerRegistrationRejectedEvent.java
@@ -3,20 +3,20 @@ package com.coc.modi.kafka.event;
 import java.time.Instant;
 import java.util.UUID;
 
-public record SellerRejectedEvent(
+public record SellerRegistrationRejectedEvent(
 		String eventId,
 		Instant occurredAt,
-		Long sellerId,
+		Long registrationId,
 		Long memberId,
 		String email
 ) {
 
-	public static SellerRejectedEvent of(Long sellerId, Long memberId, String email) {
+	public static SellerRegistrationRejectedEvent of(Long registrationId, Long memberId, String email) {
 
-		return new SellerRejectedEvent(
+		return new SellerRegistrationRejectedEvent(
 				UUID.randomUUID().toString(),
 				Instant.now(),
-				sellerId,
+				registrationId,
 				memberId,
 				email
 		);

--- a/modi/common-kafka/src/main/java/com/coc/modi/kafka/topic/KafkaTopics.java
+++ b/modi/common-kafka/src/main/java/com/coc/modi/kafka/topic/KafkaTopics.java
@@ -20,7 +20,7 @@ public final class KafkaTopics {
 	public static final String MEMBER_CREATED_EVENTS = "member-created-events";
 	public static final String MEMBER_ROLE_CHANGED_EVENTS = "member-role-changed-events";
 	public static final String SELLER_APPROVED = "seller-approved";
-	public static final String SELLER_REJECTED = "seller-rejected";
+	public static final String SELLER_REGISTRATION_REJECTED = "seller-registration-rejected";
 
 	public static final String CART_ITEM_EVENTS = "cart-item-events";
 	public static final String RENTAL_RETURNED_EVENTS = "rental-returned-events";

--- a/modi/common-kafka/src/main/java/com/coc/modi/kafka/topic/KafkaTopics.java
+++ b/modi/common-kafka/src/main/java/com/coc/modi/kafka/topic/KafkaTopics.java
@@ -19,7 +19,7 @@ public final class KafkaTopics {
 
 	public static final String MEMBER_CREATED_EVENTS = "member-created-events";
 	public static final String MEMBER_ROLE_CHANGED_EVENTS = "member-role-changed-events";
-	public static final String SELLER_APPROVED = "seller-approved";
+	public static final String SELLER_REGISTRATION_APPROVED = "seller-registration-approved";
 	public static final String SELLER_REGISTRATION_REJECTED = "seller-registration-rejected";
 
 	public static final String CART_ITEM_EVENTS = "cart-item-events";

--- a/modi/common-security/src/main/java/com/coc/modi/common/ErrorCode.java
+++ b/modi/common-security/src/main/java/com/coc/modi/common/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
 	MEMBER_ROLE_INVALID(HttpStatus.BAD_REQUEST, "MEMBER-ROLE-400", "요청한 역할 상태가 일치하지 않습니다."),
 	PHONE_DUPLICATED(HttpStatus.CONFLICT, "MEMBER-PHONE-409", "이미 사용 중인 휴대폰 번호입니다."),
 	
+	
 	ACCOUNT_BALENCE_REMAIN(HttpStatus.BAD_REQUEST, "ACCOUNT-BALANCE-REMAIN-400", "지갑에 잔액이 남아있습니다."),
 	ACCOUNT_BALENCE_CHECK(HttpStatus.NOT_FOUND, "ACCOUNT-BALANCE-404", "지갑 잔액 체크에 실패했습니다"),
 	ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "ACCOUNT-404", "지갑 정보를 찾을 수 없습니다."),
@@ -70,7 +71,9 @@ public enum ErrorCode {
 	SELLER_SETTLEMENT_CONFLICT(HttpStatus.CONFLICT, "SELLER-SETTLEMENT-409", "정산서가 이미 다른 배치로 처리되었습니다."),
 	SELLER_SETTLEMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "SELLER-SETTLEMENT-403", "정산서 소유자가 일치하지 않습니다."),
 	
-	NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTICE-404", "공지사항을 찾을 수 없습니다.");
+	ADMIN_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ADMIN-403", "관리자 권한이 없습니다."),
+	ADMIN_NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN-NOTICE-404", "공지사항을 찾을 수 없습니다."),
+	ADMIN_BLACKLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN-BLACKLIST-404", "블랙리스트 정보를 찾을 수 없습니다.");
 	
 	private final HttpStatus status;
 	private final String code;

--- a/modi/common-security/src/main/java/com/coc/modi/common/ErrorCode.java
+++ b/modi/common-security/src/main/java/com/coc/modi/common/ErrorCode.java
@@ -68,7 +68,9 @@ public enum ErrorCode {
 	SETTLEMENT_BATCH_EXECUTION_NOT_FOUND(HttpStatus.NOT_FOUND, "SETTLEMENT-BATCH-EXEC-404", "배치 실행을 찾을 수 없습니다."),
 	SELLER_SETTLEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "SELLER-SETTLEMENT-404", "정산서를 찾을 수 없습니다."),
 	SELLER_SETTLEMENT_CONFLICT(HttpStatus.CONFLICT, "SELLER-SETTLEMENT-409", "정산서가 이미 다른 배치로 처리되었습니다."),
-	SELLER_SETTLEMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "SELLER-SETTLEMENT-403", "정산서 소유자가 일치하지 않습니다.");
+	SELLER_SETTLEMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "SELLER-SETTLEMENT-403", "정산서 소유자가 일치하지 않습니다."),
+	
+	NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTICE-404", "공지사항을 찾을 수 없습니다.");
 	
 	private final HttpStatus status;
 	private final String code;

--- a/modi/common-security/src/main/java/com/coc/modi/common/auth/SecurityConfig.java
+++ b/modi/common-security/src/main/java/com/coc/modi/common/auth/SecurityConfig.java
@@ -58,12 +58,13 @@ public class SecurityConfig {
 							.requestMatchers(HttpMethod.POST, "/api/members/signup").permitAll()
 							.requestMatchers(HttpMethod.POST, "/api/auth/oauth2/connect").authenticated()
 							.requestMatchers(HttpMethod.POST, "/api/auth/**").permitAll()
-							.requestMatchers(
-									"/oauth2/**",
-									"/login/oauth2/**",
-									"/member-service/oauth2/**",
-									"/member-service/login/oauth2/**"
+						.requestMatchers(
+								"/oauth2/**",
+								"/login/oauth2/**",
+								"/member-service/oauth2/**",
+								"/member-service/login/oauth2/**"
 							).permitAll()
+							.requestMatchers(HttpMethod.GET, "/api/notices/**").permitAll()
 							.requestMatchers("/internal/**").hasRole("INTERNAL")
 							.requestMatchers("/ws/**").authenticated()
 							.requestMatchers("/actuator/**").permitAll()

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/application/BlacklistExpiryScheduler.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/application/BlacklistExpiryScheduler.java
@@ -1,0 +1,42 @@
+package com.coc.modi.member.admin.blacklist.application;
+
+import com.coc.modi.member.admin.blacklist.domain.BlacklistStatus;
+import com.coc.modi.member.admin.blacklist.domain.MemberBlacklist;
+import com.coc.modi.member.admin.blacklist.domain.MemberBlacklistRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class BlacklistExpiryScheduler {
+
+	private static final long SYSTEM_ACTOR_ID = 0L;
+
+	private final MemberBlacklistRepository blacklistRepository;
+
+	@Scheduled(fixedDelayString = "${blacklist.expiry-scan.delay-ms:600000}")
+	@Transactional
+	public void releaseExpired() {
+
+		LocalDateTime now = LocalDateTime.now();
+		List<MemberBlacklist> expired =
+				blacklistRepository.findByStatusAndSuspendedUntilBefore(BlacklistStatus.SUSPENDED, now);
+
+		if (expired.isEmpty()) {
+			return;
+		}
+
+		for (MemberBlacklist blacklist : expired) {
+			blacklist.release(null, now, SYSTEM_ACTOR_ID);
+		}
+
+		blacklistRepository.saveAll(expired);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/application/BlacklistService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/application/BlacklistService.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -41,14 +40,14 @@ public class BlacklistService {
 	private long defaultSuspendDays;
 
 	@Transactional
-	public Page<BlacklistSummaryResponse> getBlacklists(BlacklistStatus status, Pageable pageable, Long adminMemberId) {
+	public Page<BlacklistSummaryResponse> getBlacklists(BlacklistStatus status, Pageable pageable) {
 
 		Page<Member> members = (status == null)
 				? memberRepository.findAll(pageable)
 				: blacklistQueryRepository.findMembersByBlacklistStatus(status, pageable);
 
 		List<Member> content = members.getContent();
-		Map<Long, MemberBlacklist> blacklists = loadBlacklists(content, adminMemberId);
+		Map<Long, MemberBlacklist> blacklists = loadBlacklists(content);
 
 		List<BlacklistSummaryResponse> responses = content.stream()
 				.map(member -> BlacklistSummaryResponse.of(member, blacklists.get(member.getId())))
@@ -58,7 +57,7 @@ public class BlacklistService {
 	}
 
 	@Transactional
-	public BlacklistSummaryResponse searchByEmail(String email, Long adminMemberId) {
+	public BlacklistSummaryResponse searchByEmail(String email) {
 
 		if (email == null || email.isBlank()) {
 			throw new IllegalArgumentException("email은 필수입니다.");
@@ -67,17 +66,17 @@ public class BlacklistService {
 		Member member = memberRepository.findByEmail(email)
 				.orElseThrow(() -> new MemberNotFoundException(email));
 
-		MemberBlacklist blacklist = findAndApplyLazyRelease(member.getId(), adminMemberId).orElse(null);
+		MemberBlacklist blacklist = blacklistRepository.findById(member.getId()).orElse(null);
 		return BlacklistSummaryResponse.of(member, blacklist);
 	}
 
 	@Transactional
-	public BlacklistDetailResponse getBlacklistDetail(Long memberId, Long adminMemberId) {
+	public BlacklistDetailResponse getBlacklistDetail(Long memberId) {
 
 		Member member = memberRepository.findById(memberId)
 				.orElseThrow(() -> new MemberNotFoundException(memberId));
 
-		MemberBlacklist blacklist = findAndApplyLazyRelease(memberId, adminMemberId).orElse(null);
+		MemberBlacklist blacklist = blacklistRepository.findById(memberId).orElse(null);
 		return BlacklistDetailResponse.of(member, blacklist);
 	}
 
@@ -127,7 +126,7 @@ public class BlacklistService {
 		return BlacklistDetailResponse.of(member, saved);
 	}
 
-	private Map<Long, MemberBlacklist> loadBlacklists(List<Member> members, Long adminMemberId) {
+	private Map<Long, MemberBlacklist> loadBlacklists(List<Member> members) {
 
 		List<Long> memberIds = members.stream()
 				.map(Member::getId)
@@ -138,38 +137,8 @@ public class BlacklistService {
 		}
 
 		List<MemberBlacklist> blacklists = blacklistRepository.findByMemberIdIn(memberIds);
-		List<MemberBlacklist> expired = new ArrayList<>();
-		LocalDateTime now = LocalDateTime.now();
-
-		for (MemberBlacklist blacklist : blacklists) {
-			if (blacklist.isExpired(now)) {
-				blacklist.release(null, now, adminMemberId);
-				expired.add(blacklist);
-			}
-		}
-
-		if (!expired.isEmpty()) {
-			blacklistRepository.saveAll(expired);
-		}
-
 		return blacklists.stream()
 				.collect(Collectors.toMap(MemberBlacklist::getMemberId, blacklist -> blacklist));
-	}
-
-	private Optional<MemberBlacklist> findAndApplyLazyRelease(Long memberId, Long adminMemberId) {
-
-		Optional<MemberBlacklist> optional = blacklistRepository.findById(memberId);
-		if (optional.isEmpty()) {
-			return Optional.empty();
-		}
-
-		MemberBlacklist blacklist = optional.get();
-		if (blacklist.isExpired(LocalDateTime.now())) {
-			blacklist.release(null, LocalDateTime.now(), adminMemberId);
-			return Optional.of(blacklistRepository.save(blacklist));
-		}
-
-		return optional;
 	}
 
 	private void validateSuspendCommand(BlacklistSuspendCommand command) {

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/application/BlacklistService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/application/BlacklistService.java
@@ -1,0 +1,203 @@
+package com.coc.modi.member.admin.blacklist.application;
+
+import com.coc.modi.member.admin.blacklist.application.dto.BlacklistDetailResponse;
+import com.coc.modi.member.admin.blacklist.application.dto.BlacklistReleaseCommand;
+import com.coc.modi.member.admin.blacklist.application.dto.BlacklistSummaryResponse;
+import com.coc.modi.member.admin.blacklist.application.dto.BlacklistSuspendCommand;
+import com.coc.modi.member.admin.blacklist.domain.BlacklistStatus;
+import com.coc.modi.member.admin.blacklist.domain.MemberBlacklist;
+import com.coc.modi.member.admin.blacklist.domain.MemberBlacklistRepository;
+import com.coc.modi.member.admin.blacklist.exception.BlacklistNotFoundException;
+import com.coc.modi.member.admin.blacklist.infrastructure.MemberBlacklistQueryRepository;
+import com.coc.modi.member.member.domain.Member;
+import com.coc.modi.member.member.domain.MemberRepository;
+import com.coc.modi.member.member.exception.MemberNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BlacklistService {
+
+	private final MemberRepository memberRepository;
+	private final MemberBlacklistRepository blacklistRepository;
+	private final MemberBlacklistQueryRepository blacklistQueryRepository;
+
+	@Value("${blacklist.default-days:7}")
+	private long defaultSuspendDays;
+
+	@Transactional
+	public Page<BlacklistSummaryResponse> getBlacklists(BlacklistStatus status, Pageable pageable, Long adminMemberId) {
+
+		Page<Member> members = (status == null)
+				? memberRepository.findAll(pageable)
+				: blacklistQueryRepository.findMembersByBlacklistStatus(status, pageable);
+
+		List<Member> content = members.getContent();
+		Map<Long, MemberBlacklist> blacklists = loadBlacklists(content, adminMemberId);
+
+		List<BlacklistSummaryResponse> responses = content.stream()
+				.map(member -> BlacklistSummaryResponse.of(member, blacklists.get(member.getId())))
+				.toList();
+
+		return new PageImpl<>(responses, pageable, members.getTotalElements());
+	}
+
+	@Transactional
+	public BlacklistSummaryResponse searchByEmail(String email, Long adminMemberId) {
+
+		if (email == null || email.isBlank()) {
+			throw new IllegalArgumentException("email은 필수입니다.");
+		}
+
+		Member member = memberRepository.findByEmail(email)
+				.orElseThrow(() -> new MemberNotFoundException(email));
+
+		MemberBlacklist blacklist = findAndApplyLazyRelease(member.getId(), adminMemberId).orElse(null);
+		return BlacklistSummaryResponse.of(member, blacklist);
+	}
+
+	@Transactional
+	public BlacklistDetailResponse getBlacklistDetail(Long memberId, Long adminMemberId) {
+
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new MemberNotFoundException(memberId));
+
+		MemberBlacklist blacklist = findAndApplyLazyRelease(memberId, adminMemberId).orElse(null);
+		return BlacklistDetailResponse.of(member, blacklist);
+	}
+
+	@Transactional
+	public BlacklistDetailResponse suspend(BlacklistSuspendCommand command) {
+
+		validateSuspendCommand(command);
+
+		Member member = memberRepository.findById(command.memberId())
+				.orElseThrow(() -> new MemberNotFoundException(command.memberId()));
+
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime suspendedUntil = now.plusDays(defaultSuspendDays);
+
+		Optional<MemberBlacklist> optionalBlacklist = blacklistRepository.findById(command.memberId());
+
+		MemberBlacklist blacklist = optionalBlacklist.orElseGet(() -> MemberBlacklist.suspend(
+						command.memberId(),
+						command.reason(),
+						command.memo(),
+						now,
+						suspendedUntil,
+						command.createdBy()
+				));
+
+		if (optionalBlacklist.isPresent()) {
+			blacklist.updateSuspension(command.reason(), command.memo(), now, suspendedUntil, command.createdBy());
+		}
+
+		MemberBlacklist saved = blacklistRepository.save(blacklist);
+		return BlacklistDetailResponse.of(member, saved);
+	}
+
+	@Transactional
+	public BlacklistDetailResponse release(BlacklistReleaseCommand command) {
+
+		validateReleaseCommand(command);
+
+		Member member = memberRepository.findById(command.memberId())
+				.orElseThrow(() -> new MemberNotFoundException(command.memberId()));
+
+		MemberBlacklist blacklist = blacklistRepository.findById(command.memberId())
+				.orElseThrow(() -> new BlacklistNotFoundException(command.memberId()));
+
+		blacklist.release(command.memo(), LocalDateTime.now(), command.releasedBy());
+		MemberBlacklist saved = blacklistRepository.save(blacklist);
+		return BlacklistDetailResponse.of(member, saved);
+	}
+
+	private Map<Long, MemberBlacklist> loadBlacklists(List<Member> members, Long adminMemberId) {
+
+		List<Long> memberIds = members.stream()
+				.map(Member::getId)
+				.toList();
+
+		if (memberIds.isEmpty()) {
+			return Map.of();
+		}
+
+		List<MemberBlacklist> blacklists = blacklistRepository.findByMemberIdIn(memberIds);
+		List<MemberBlacklist> expired = new ArrayList<>();
+		LocalDateTime now = LocalDateTime.now();
+
+		for (MemberBlacklist blacklist : blacklists) {
+			if (blacklist.isExpired(now)) {
+				blacklist.release(null, now, adminMemberId);
+				expired.add(blacklist);
+			}
+		}
+
+		if (!expired.isEmpty()) {
+			blacklistRepository.saveAll(expired);
+		}
+
+		return blacklists.stream()
+				.collect(Collectors.toMap(MemberBlacklist::getMemberId, blacklist -> blacklist));
+	}
+
+	private Optional<MemberBlacklist> findAndApplyLazyRelease(Long memberId, Long adminMemberId) {
+
+		Optional<MemberBlacklist> optional = blacklistRepository.findById(memberId);
+		if (optional.isEmpty()) {
+			return Optional.empty();
+		}
+
+		MemberBlacklist blacklist = optional.get();
+		if (blacklist.isExpired(LocalDateTime.now())) {
+			blacklist.release(null, LocalDateTime.now(), adminMemberId);
+			return Optional.of(blacklistRepository.save(blacklist));
+		}
+
+		return optional;
+	}
+
+	private void validateSuspendCommand(BlacklistSuspendCommand command) {
+
+		if (command == null) {
+			throw new IllegalArgumentException("요청 본문이 비어 있습니다.");
+		}
+		if (command.memberId() == null) {
+			throw new IllegalArgumentException("memberId는 필수입니다.");
+		}
+		if (command.reason() == null || command.reason().isBlank()) {
+			throw new IllegalArgumentException("정지 사유는 필수입니다.");
+		}
+		if (command.createdBy() == null) {
+			throw new IllegalArgumentException("createdBy는 필수입니다.");
+		}
+	}
+
+	private void validateReleaseCommand(BlacklistReleaseCommand command) {
+
+		if (command == null) {
+			throw new IllegalArgumentException("요청 본문이 비어 있습니다.");
+		}
+		if (command.memberId() == null) {
+			throw new IllegalArgumentException("memberId는 필수입니다.");
+		}
+		if (command.releasedBy() == null) {
+			throw new IllegalArgumentException("releasedBy는 필수입니다.");
+		}
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/application/dto/BlacklistDetailResponse.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/application/dto/BlacklistDetailResponse.java
@@ -1,0 +1,58 @@
+package com.coc.modi.member.admin.blacklist.application.dto;
+
+import com.coc.modi.member.admin.blacklist.domain.BlacklistStatus;
+import com.coc.modi.member.admin.blacklist.domain.MemberBlacklist;
+import com.coc.modi.member.member.domain.Member;
+
+import java.time.LocalDateTime;
+
+public record BlacklistDetailResponse(
+		Long memberId,
+		String email,
+		String name,
+		String phone,
+		BlacklistStatus status,
+		String reason,
+		String memo,
+		LocalDateTime suspendedAt,
+		LocalDateTime suspendedUntil,
+		LocalDateTime releasedAt,
+		LocalDateTime createdAt,
+		LocalDateTime updatedAt
+) {
+
+	public static BlacklistDetailResponse of(Member member, MemberBlacklist blacklist) {
+
+		if (blacklist == null) {
+			return new BlacklistDetailResponse(
+					member.getId(),
+					member.getEmail(),
+					member.getName(),
+					member.getPhone(),
+					BlacklistStatus.ACTIVE,
+					null,
+					null,
+					null,
+					null,
+					null,
+					member.getCreatedAt(),
+					member.getUpdatedAt()
+			);
+		}
+
+		return new BlacklistDetailResponse(
+				member.getId(),
+				member.getEmail(),
+				member.getName(),
+				member.getPhone(),
+				blacklist.getStatus(),
+				blacklist.getReason(),
+				blacklist.getMemo(),
+				blacklist.getSuspendedAt(),
+				blacklist.getSuspendedUntil(),
+				blacklist.getReleasedAt(),
+				blacklist.getCreatedAt(),
+				blacklist.getUpdatedAt()
+		);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/application/dto/BlacklistReleaseCommand.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/application/dto/BlacklistReleaseCommand.java
@@ -1,0 +1,8 @@
+package com.coc.modi.member.admin.blacklist.application.dto;
+
+public record BlacklistReleaseCommand(
+		Long memberId,
+		String memo,
+		Long releasedBy
+) {
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/application/dto/BlacklistSummaryResponse.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/application/dto/BlacklistSummaryResponse.java
@@ -1,0 +1,43 @@
+package com.coc.modi.member.admin.blacklist.application.dto;
+
+import com.coc.modi.member.admin.blacklist.domain.BlacklistStatus;
+import com.coc.modi.member.admin.blacklist.domain.MemberBlacklist;
+import com.coc.modi.member.member.domain.Member;
+
+import java.time.LocalDateTime;
+
+public record BlacklistSummaryResponse(
+		Long memberId,
+		String email,
+		String name,
+		BlacklistStatus status,
+		LocalDateTime suspendedAt,
+		LocalDateTime suspendedUntil,
+		LocalDateTime releasedAt
+) {
+
+	public static BlacklistSummaryResponse of(Member member, MemberBlacklist blacklist) {
+
+		if (blacklist == null) {
+			return new BlacklistSummaryResponse(
+					member.getId(),
+					member.getEmail(),
+					member.getName(),
+					BlacklistStatus.ACTIVE,
+					null,
+					null,
+					null
+			);
+		}
+
+		return new BlacklistSummaryResponse(
+				member.getId(),
+				member.getEmail(),
+				member.getName(),
+				blacklist.getStatus(),
+				blacklist.getSuspendedAt(),
+				blacklist.getSuspendedUntil(),
+				blacklist.getReleasedAt()
+		);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/application/dto/BlacklistSuspendCommand.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/application/dto/BlacklistSuspendCommand.java
@@ -1,0 +1,9 @@
+package com.coc.modi.member.admin.blacklist.application.dto;
+
+public record BlacklistSuspendCommand(
+		Long memberId,
+		String reason,
+		String memo,
+		Long createdBy
+) {
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/domain/BlacklistStatus.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/domain/BlacklistStatus.java
@@ -1,0 +1,6 @@
+package com.coc.modi.member.admin.blacklist.domain;
+
+public enum BlacklistStatus {
+	ACTIVE,
+	SUSPENDED
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/domain/MemberBlacklist.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/domain/MemberBlacklist.java
@@ -1,0 +1,126 @@
+package com.coc.modi.member.admin.blacklist.domain;
+
+import com.coc.modi.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "member_blacklist", schema = "admin")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberBlacklist extends BaseEntity {
+
+	@Id
+	@Column(name = "member_id")
+	private Long memberId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private BlacklistStatus status;
+
+	@Column(nullable = false, length = 500)
+	private String reason;
+
+	@Column(length = 1000)
+	private String memo;
+
+	@Column(name = "suspended_at")
+	private LocalDateTime suspendedAt;
+
+	@Column(name = "suspended_until")
+	private LocalDateTime suspendedUntil;
+
+	@Column(name = "released_at")
+	private LocalDateTime releasedAt;
+
+	@Column(name = "created_by", nullable = false)
+	private Long createdBy;
+
+	@Column(name = "updated_by", nullable = false)
+	private Long updatedBy;
+
+	private MemberBlacklist(Long memberId,
+							BlacklistStatus status,
+							String reason,
+							String memo,
+							LocalDateTime suspendedAt,
+							LocalDateTime suspendedUntil,
+							LocalDateTime releasedAt,
+							Long createdBy,
+							Long updatedBy) {
+
+		this.memberId = memberId;
+		this.status = status;
+		this.reason = reason;
+		this.memo = memo;
+		this.suspendedAt = suspendedAt;
+		this.suspendedUntil = suspendedUntil;
+		this.releasedAt = releasedAt;
+		this.createdBy = createdBy;
+		this.updatedBy = updatedBy;
+	}
+
+	public static MemberBlacklist suspend(Long memberId,
+										  String reason,
+										  String memo,
+										  LocalDateTime suspendedAt,
+										  LocalDateTime suspendedUntil,
+										  Long actorId) {
+
+		return new MemberBlacklist(
+				memberId,
+				BlacklistStatus.SUSPENDED,
+				reason,
+				memo,
+				suspendedAt,
+				suspendedUntil,
+				null,
+				actorId,
+				actorId
+		);
+	}
+
+	public void updateSuspension(String reason,
+								 String memo,
+								 LocalDateTime suspendedAt,
+								 LocalDateTime suspendedUntil,
+								 Long actorId) {
+
+		this.status = BlacklistStatus.SUSPENDED;
+		this.reason = reason;
+		this.memo = memo;
+		this.suspendedAt = suspendedAt;
+		this.suspendedUntil = suspendedUntil;
+		this.releasedAt = null;
+		this.updatedBy = actorId;
+	}
+
+	public void release(String memo, LocalDateTime releasedAt, Long actorId) {
+
+		this.status = BlacklistStatus.ACTIVE;
+		if (memo != null) {
+			this.memo = memo;
+		}
+		this.releasedAt = releasedAt;
+		this.suspendedAt = null;
+		this.suspendedUntil = null;
+		this.updatedBy = actorId;
+	}
+
+	public boolean isExpired(LocalDateTime now) {
+
+		return status == BlacklistStatus.SUSPENDED
+				&& suspendedUntil != null
+				&& now.isAfter(suspendedUntil);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/domain/MemberBlacklistRepository.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/domain/MemberBlacklistRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface MemberBlacklistRepository extends JpaRepository<MemberBlacklist, Long> {
@@ -11,4 +12,6 @@ public interface MemberBlacklistRepository extends JpaRepository<MemberBlacklist
 	Page<MemberBlacklist> findByStatus(BlacklistStatus status, Pageable pageable);
 
 	List<MemberBlacklist> findByMemberIdIn(List<Long> memberIds);
+
+	List<MemberBlacklist> findByStatusAndSuspendedUntilBefore(BlacklistStatus status, LocalDateTime suspendedUntil);
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/domain/MemberBlacklistRepository.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/domain/MemberBlacklistRepository.java
@@ -1,0 +1,14 @@
+package com.coc.modi.member.admin.blacklist.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MemberBlacklistRepository extends JpaRepository<MemberBlacklist, Long> {
+
+	Page<MemberBlacklist> findByStatus(BlacklistStatus status, Pageable pageable);
+
+	List<MemberBlacklist> findByMemberIdIn(List<Long> memberIds);
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/exception/BlacklistException.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/exception/BlacklistException.java
@@ -1,0 +1,19 @@
+package com.coc.modi.member.admin.blacklist.exception;
+
+import com.coc.modi.common.ErrorCode;
+import com.coc.modi.member.admin.exception.AdminException;
+
+public class BlacklistException extends AdminException {
+
+	public BlacklistException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public BlacklistException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
+
+	public BlacklistException(ErrorCode errorCode, String message, Throwable cause) {
+		super(errorCode, message, cause);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/exception/BlacklistNotFoundException.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/exception/BlacklistNotFoundException.java
@@ -1,0 +1,10 @@
+package com.coc.modi.member.admin.blacklist.exception;
+
+import com.coc.modi.common.ErrorCode;
+
+public class BlacklistNotFoundException extends BlacklistException {
+
+	public BlacklistNotFoundException(Long memberId) {
+		super(ErrorCode.ADMIN_BLACKLIST_NOT_FOUND, "블랙리스트 정보를 찾을 수 없습니다. memberId=" + memberId);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/infrastructure/MemberBlacklistQueryRepository.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/infrastructure/MemberBlacklistQueryRepository.java
@@ -1,0 +1,84 @@
+package com.coc.modi.member.admin.blacklist.infrastructure;
+
+import com.coc.modi.member.admin.blacklist.domain.BlacklistStatus;
+import com.coc.modi.member.admin.blacklist.domain.MemberBlacklist;
+import com.coc.modi.member.member.domain.Member;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberBlacklistQueryRepository {
+
+	private static final Set<String> MEMBER_SORT_FIELDS = Set.of("id", "email", "name", "createdAt", "status");
+
+	private final EntityManager entityManager;
+
+	public Page<Member> findMembersByBlacklistStatus(BlacklistStatus status, Pageable pageable) {
+
+		String alias = "m";
+		String join = " from Member " + alias;
+		String where;
+		boolean hasStatus = status != null;
+
+		if (status == BlacklistStatus.SUSPENDED) {
+			join += " join " + MemberBlacklist.class.getSimpleName() + " b on " + alias + ".id = b.memberId";
+			where = " where b.status = :status";
+		} else {
+			join += " left join " + MemberBlacklist.class.getSimpleName() + " b on " + alias + ".id = b.memberId";
+			where = " where b is null or b.status = :status";
+		}
+
+		String orderBy = buildOrderBy(alias, pageable.getSort());
+		String selectQuery = "select " + alias + join + where + orderBy;
+		String countQuery = "select count(" + alias + ")" + join + where;
+
+		TypedQuery<Member> query = entityManager.createQuery(selectQuery, Member.class);
+		TypedQuery<Long> count = entityManager.createQuery(countQuery, Long.class);
+		if (hasStatus) {
+			query.setParameter("status", status);
+			count.setParameter("status", status);
+		}
+
+		query.setFirstResult((int) pageable.getOffset());
+		query.setMaxResults(pageable.getPageSize());
+
+		List<Member> content = query.getResultList();
+		long total = count.getSingleResult();
+		return new PageImpl<>(content, pageable, total);
+	}
+
+	private String buildOrderBy(String alias, Sort sort) {
+
+		if (sort == null || sort.isUnsorted()) {
+			return "";
+		}
+
+		List<String> orders = new ArrayList<>();
+		for (Sort.Order order : sort) {
+			if (!MEMBER_SORT_FIELDS.contains(order.getProperty())) {
+				continue;
+			}
+			String direction = order.isAscending() ? "asc" : "desc";
+			orders.add(alias + "." + order.getProperty() + " " + direction);
+		}
+
+		if (orders.isEmpty()) {
+			return "";
+		}
+
+		return " order by " + String.join(", ", orders);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/presentation/AdminBlacklistController.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/presentation/AdminBlacklistController.java
@@ -45,7 +45,7 @@ public class AdminBlacklistController {
 
 		requireAdmin(member);
 		Page<BlacklistSummaryResponse> responses =
-				blacklistService.getBlacklists(status, pageable, member.memberId());
+				blacklistService.getBlacklists(status, pageable);
 		return ResponseEntity.ok(ApiResponse.ok(responses));
 	}
 
@@ -56,7 +56,7 @@ public class AdminBlacklistController {
 	) {
 
 		requireAdmin(member);
-		BlacklistSummaryResponse response = blacklistService.searchByEmail(email, member.memberId());
+		BlacklistSummaryResponse response = blacklistService.searchByEmail(email);
 		return ResponseEntity.ok(ApiResponse.ok(response));
 	}
 
@@ -67,7 +67,7 @@ public class AdminBlacklistController {
 	) {
 
 		requireAdmin(member);
-		BlacklistDetailResponse response = blacklistService.getBlacklistDetail(memberId, member.memberId());
+		BlacklistDetailResponse response = blacklistService.getBlacklistDetail(memberId);
 		return ResponseEntity.ok(ApiResponse.ok(response));
 	}
 

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/presentation/AdminBlacklistController.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/presentation/AdminBlacklistController.java
@@ -1,0 +1,107 @@
+package com.coc.modi.member.admin.blacklist.presentation;
+
+import com.coc.modi.common.ApiResponse;
+import com.coc.modi.common.auth.CustomMember;
+import com.coc.modi.member.admin.blacklist.application.BlacklistService;
+import com.coc.modi.member.admin.blacklist.application.dto.BlacklistDetailResponse;
+import com.coc.modi.member.admin.blacklist.application.dto.BlacklistSummaryResponse;
+import com.coc.modi.member.admin.blacklist.domain.BlacklistStatus;
+import com.coc.modi.member.admin.blacklist.presentation.dto.BlacklistReleaseRequest;
+import com.coc.modi.member.admin.blacklist.presentation.dto.BlacklistSuspendRequest;
+import com.coc.modi.member.admin.exception.AdminAccessDeniedException;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/blacklists")
+public class AdminBlacklistController {
+
+	private final BlacklistService blacklistService;
+
+	@GetMapping
+	public ResponseEntity<ApiResponse<Page<BlacklistSummaryResponse>>> getBlacklists(
+			@AuthenticationPrincipal CustomMember member,
+			@RequestParam(required = false) BlacklistStatus status,
+			@PageableDefault Pageable pageable
+	) {
+
+		requireAdmin(member);
+		Page<BlacklistSummaryResponse> responses =
+				blacklistService.getBlacklists(status, pageable, member.memberId());
+		return ResponseEntity.ok(ApiResponse.ok(responses));
+	}
+
+	@GetMapping("/search")
+	public ResponseEntity<ApiResponse<BlacklistSummaryResponse>> searchByEmail(
+			@AuthenticationPrincipal CustomMember member,
+			@RequestParam @NotBlank String email
+	) {
+
+		requireAdmin(member);
+		BlacklistSummaryResponse response = blacklistService.searchByEmail(email, member.memberId());
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+
+	@GetMapping("/{memberId}")
+	public ResponseEntity<ApiResponse<BlacklistDetailResponse>> getBlacklistDetail(
+			@AuthenticationPrincipal CustomMember member,
+			@PathVariable Long memberId
+	) {
+
+		requireAdmin(member);
+		BlacklistDetailResponse response = blacklistService.getBlacklistDetail(memberId, member.memberId());
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+
+	@PostMapping
+	public ResponseEntity<ApiResponse<BlacklistDetailResponse>> suspend(
+			@AuthenticationPrincipal CustomMember member,
+			@Valid @RequestBody BlacklistSuspendRequest request
+	) {
+
+		requireAdmin(member);
+		BlacklistDetailResponse response = blacklistService.suspend(request.toCommand(member.memberId()));
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(response));
+	}
+
+	@PatchMapping("/{memberId}/release")
+	public ResponseEntity<ApiResponse<BlacklistDetailResponse>> release(
+			@AuthenticationPrincipal CustomMember member,
+			@PathVariable Long memberId,
+			@Valid @RequestBody(required = false) BlacklistReleaseRequest request
+	) {
+
+		requireAdmin(member);
+		BlacklistReleaseRequest releaseRequest = (request == null)
+				? new BlacklistReleaseRequest(null)
+				: request;
+		BlacklistDetailResponse response =
+				blacklistService.release(releaseRequest.toCommand(memberId, member.memberId()));
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+
+	private void requireAdmin(CustomMember member) {
+
+		if (member == null || !"ADMIN".equals(member.role())) {
+			throw new AdminAccessDeniedException("관리자 권한이 필요합니다.");
+		}
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/presentation/dto/BlacklistReleaseRequest.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/presentation/dto/BlacklistReleaseRequest.java
@@ -1,0 +1,15 @@
+package com.coc.modi.member.admin.blacklist.presentation.dto;
+
+import com.coc.modi.member.admin.blacklist.application.dto.BlacklistReleaseCommand;
+
+import jakarta.validation.constraints.Size;
+
+public record BlacklistReleaseRequest(
+		@Size(max = 1000) String memo
+) {
+
+	public BlacklistReleaseCommand toCommand(Long memberId, Long releasedBy) {
+
+		return new BlacklistReleaseCommand(memberId, memo, releasedBy);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/presentation/dto/BlacklistSuspendRequest.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/blacklist/presentation/dto/BlacklistSuspendRequest.java
@@ -1,0 +1,19 @@
+package com.coc.modi.member.admin.blacklist.presentation.dto;
+
+import com.coc.modi.member.admin.blacklist.application.dto.BlacklistSuspendCommand;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record BlacklistSuspendRequest(
+		@NotNull Long memberId,
+		@NotBlank @Size(max = 500) String reason,
+		@Size(max = 1000) String memo
+) {
+
+	public BlacklistSuspendCommand toCommand(Long createdBy) {
+
+		return new BlacklistSuspendCommand(memberId, reason, memo, createdBy);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/exception/AdminAccessDeniedException.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/exception/AdminAccessDeniedException.java
@@ -1,0 +1,10 @@
+package com.coc.modi.member.admin.exception;
+
+import com.coc.modi.common.ErrorCode;
+
+public class AdminAccessDeniedException extends AdminException {
+
+	public AdminAccessDeniedException(String message) {
+		super(ErrorCode.ADMIN_ACCESS_DENIED, message);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/exception/AdminException.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/exception/AdminException.java
@@ -1,0 +1,19 @@
+package com.coc.modi.member.admin.exception;
+
+import com.coc.modi.common.ErrorCode;
+import com.coc.modi.member.member.exception.MemberException;
+
+public class AdminException extends MemberException {
+
+	public AdminException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public AdminException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
+
+	public AdminException(ErrorCode errorCode, String message, Throwable cause) {
+		super(errorCode, message, cause);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/application/NoticeService.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/application/NoticeService.java
@@ -1,0 +1,172 @@
+package com.coc.modi.member.admin.notice.application;
+
+import com.coc.modi.member.admin.notice.application.dto.NoticeCreateCommand;
+import com.coc.modi.member.admin.notice.application.dto.NoticeResponse;
+import com.coc.modi.member.admin.notice.application.dto.NoticeSummaryResponse;
+import com.coc.modi.member.admin.notice.application.dto.NoticeUpdateCommand;
+import com.coc.modi.member.admin.notice.domain.Notice;
+import com.coc.modi.member.admin.notice.domain.NoticeRepository;
+import com.coc.modi.member.admin.notice.domain.NoticeStatus;
+import com.coc.modi.member.admin.notice.exception.NoticeNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeService {
+
+	private final NoticeRepository noticeRepository;
+
+	@Transactional
+	public NoticeResponse createNotice(NoticeCreateCommand command) {
+
+		validateCommand(command);
+
+		NoticeStatus status = command.status() != null ? command.status() : NoticeStatus.DRAFT;
+		if (status == NoticeStatus.DELETED) {
+			throw new IllegalArgumentException("삭제 상태로 생성할 수 없습니다.");
+		}
+
+		Notice notice = Notice.create(
+				command.title(),
+				command.content(),
+				status,
+				command.pinned(),
+				command.displayStartAt(),
+				command.displayEndAt(),
+				command.createdBy()
+		);
+
+		Notice saved = noticeRepository.save(notice);
+		return NoticeResponse.from(saved);
+	}
+
+	@Transactional
+	public NoticeResponse updateNotice(NoticeUpdateCommand command) {
+
+		if (command == null || command.noticeId() == null) {
+			throw new IllegalArgumentException("noticeId는 필수입니다.");
+		}
+		validatePeriod(command.displayStartAt(), command.displayEndAt());
+
+		Notice notice = findNotice(command.noticeId());
+		if (notice.getStatus() == NoticeStatus.DELETED) {
+			throw new IllegalStateException("삭제된 공지사항은 수정할 수 없습니다.");
+		}
+
+		notice.update(
+				command.title(),
+				command.content(),
+				command.pinned(),
+				command.displayStartAt(),
+				command.displayEndAt()
+		);
+
+		return NoticeResponse.from(notice);
+	}
+
+	@Transactional
+	public void deleteNotice(Long noticeId) {
+
+		Notice notice = findNotice(noticeId);
+		notice.delete();
+	}
+
+	@Transactional
+	public NoticeResponse publishNotice(Long noticeId) {
+
+		Notice notice = findNotice(noticeId);
+		if (notice.getStatus() == NoticeStatus.DELETED) {
+			throw new IllegalStateException("삭제된 공지사항은 발행할 수 없습니다.");
+		}
+		notice.publish();
+		return NoticeResponse.from(notice);
+	}
+
+	@Transactional
+	public NoticeResponse draftNotice(Long noticeId) {
+
+		Notice notice = findNotice(noticeId);
+		if (notice.getStatus() == NoticeStatus.DELETED) {
+			throw new IllegalStateException("삭제된 공지사항은 비노출로 전환할 수 없습니다.");
+		}
+		notice.draft();
+		return NoticeResponse.from(notice);
+	}
+
+	public Page<NoticeSummaryResponse> getPublishedNotices(String keyword, Pageable pageable) {
+
+		String normalized = normalizeKeyword(keyword);
+		Page<Notice> notices = noticeRepository.findPublishedVisible(
+				NoticeStatus.PUBLISHED,
+				LocalDateTime.now(),
+				normalized,
+				pageable
+		);
+		return notices.map(NoticeSummaryResponse::from);
+	}
+
+	@Transactional
+	public NoticeResponse getPublishedNotice(Long noticeId) {
+
+		Notice notice = noticeRepository.findPublishedVisibleById(
+						noticeId,
+						NoticeStatus.PUBLISHED,
+						LocalDateTime.now()
+				)
+				.orElseThrow(() -> new NoticeNotFoundException("공지사항을 찾을 수 없습니다. noticeId=" + noticeId));
+
+		notice.increaseViewCount();
+		return NoticeResponse.from(notice);
+	}
+
+	private Notice findNotice(Long noticeId) {
+
+		return noticeRepository.findById(noticeId)
+				.orElseThrow(() -> new NoticeNotFoundException("공지사항을 찾을 수 없습니다. noticeId=" + noticeId));
+	}
+
+	private void validateCommand(NoticeCreateCommand command) {
+
+		if (command == null) {
+			throw new IllegalArgumentException("요청 본문이 비어 있습니다.");
+		}
+		if (command.title() == null || command.title().isBlank()) {
+			throw new IllegalArgumentException("제목은 필수입니다.");
+		}
+		if (command.content() == null || command.content().isBlank()) {
+			throw new IllegalArgumentException("내용은 필수입니다.");
+		}
+		if (command.createdBy() == null) {
+			throw new IllegalArgumentException("createdBy는 필수입니다.");
+		}
+		validatePeriod(command.displayStartAt(), command.displayEndAt());
+	}
+
+	private void validatePeriod(LocalDateTime startAt, LocalDateTime endAt) {
+
+		if (startAt != null && endAt != null && startAt.isAfter(endAt)) {
+			throw new IllegalArgumentException("노출 시작일시는 종료일시보다 이후일 수 없습니다.");
+		}
+	}
+
+	private String normalizeKeyword(String keyword) {
+
+		if (keyword == null) {
+			return null;
+		}
+		String trimmed = keyword.trim();
+		if (trimmed.isEmpty()) {
+			return null;
+		}
+		return "%" + trimmed.toLowerCase() + "%";
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/application/dto/NoticeCreateCommand.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/application/dto/NoticeCreateCommand.java
@@ -1,0 +1,16 @@
+package com.coc.modi.member.admin.notice.application.dto;
+
+import java.time.LocalDateTime;
+
+import com.coc.modi.member.admin.notice.domain.NoticeStatus;
+
+public record NoticeCreateCommand(
+		String title,
+		String content,
+		NoticeStatus status,
+		boolean pinned,
+		LocalDateTime displayStartAt,
+		LocalDateTime displayEndAt,
+		Long createdBy
+) {
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/application/dto/NoticeResponse.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/application/dto/NoticeResponse.java
@@ -1,0 +1,35 @@
+package com.coc.modi.member.admin.notice.application.dto;
+
+import com.coc.modi.member.admin.notice.domain.Notice;
+import com.coc.modi.member.admin.notice.domain.NoticeStatus;
+
+import java.time.LocalDateTime;
+
+public record NoticeResponse(
+		Long id,
+		String title,
+		String content,
+		NoticeStatus status,
+		boolean pinned,
+		long viewCount,
+		LocalDateTime displayStartAt,
+		LocalDateTime displayEndAt,
+		LocalDateTime createdAt,
+		LocalDateTime updatedAt
+) {
+	public static NoticeResponse from(Notice notice) {
+
+		return new NoticeResponse(
+				notice.getId(),
+				notice.getTitle(),
+				notice.getContent(),
+				notice.getStatus(),
+				notice.isPinned(),
+				notice.getViewCount(),
+				notice.getDisplayStartAt(),
+				notice.getDisplayEndAt(),
+				notice.getCreatedAt(),
+				notice.getUpdatedAt()
+		);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/application/dto/NoticeSummaryResponse.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/application/dto/NoticeSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.coc.modi.member.admin.notice.application.dto;
+
+import com.coc.modi.member.admin.notice.domain.Notice;
+
+import java.time.LocalDateTime;
+
+public record NoticeSummaryResponse(
+		Long id,
+		String title,
+		boolean pinned,
+		long viewCount,
+		LocalDateTime createdAt
+) {
+	public static NoticeSummaryResponse from(Notice notice) {
+
+		return new NoticeSummaryResponse(
+				notice.getId(),
+				notice.getTitle(),
+				notice.isPinned(),
+				notice.getViewCount(),
+				notice.getCreatedAt()
+		);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/application/dto/NoticeUpdateCommand.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/application/dto/NoticeUpdateCommand.java
@@ -1,0 +1,13 @@
+package com.coc.modi.member.admin.notice.application.dto;
+
+import java.time.LocalDateTime;
+
+public record NoticeUpdateCommand(
+		Long noticeId,
+		String title,
+		String content,
+		Boolean pinned,
+		LocalDateTime displayStartAt,
+		LocalDateTime displayEndAt
+) {
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/domain/Notice.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/domain/Notice.java
@@ -1,0 +1,125 @@
+package com.coc.modi.member.admin.notice.domain;
+
+import com.coc.modi.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "notice", schema = "member")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notice extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, length = 200)
+	private String title;
+
+	@Column(nullable = false, columnDefinition = "TEXT")
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private NoticeStatus status;
+
+	@Column(nullable = false)
+	private boolean pinned;
+
+	@Column(nullable = false)
+	private long viewCount;
+
+	@Column(name = "display_start_at")
+	private LocalDateTime displayStartAt;
+
+	@Column(name = "display_end_at")
+	private LocalDateTime displayEndAt;
+
+	@Column(name = "created_by", nullable = false)
+	private Long createdBy;
+
+	private Notice(String title,
+				   String content,
+				   NoticeStatus status,
+				   boolean pinned,
+				   LocalDateTime displayStartAt,
+				   LocalDateTime displayEndAt,
+				   Long createdBy) {
+
+		this.title = title;
+		this.content = content;
+		this.status = status;
+		this.pinned = pinned;
+		this.viewCount = 0L;
+		this.displayStartAt = displayStartAt;
+		this.displayEndAt = displayEndAt;
+		this.createdBy = createdBy;
+	}
+
+	public static Notice create(String title,
+								String content,
+								NoticeStatus status,
+								boolean pinned,
+								LocalDateTime displayStartAt,
+								LocalDateTime displayEndAt,
+								Long createdBy) {
+
+		return new Notice(title, content, status, pinned, displayStartAt, displayEndAt, createdBy);
+	}
+
+	public void update(String title,
+					   String content,
+					   Boolean pinned,
+					   LocalDateTime displayStartAt,
+					   LocalDateTime displayEndAt) {
+
+		if (title != null) {
+			this.title = title;
+		}
+		if (content != null) {
+			this.content = content;
+		}
+		if (pinned != null) {
+			this.pinned = pinned;
+		}
+		if (displayStartAt != null) {
+			this.displayStartAt = displayStartAt;
+		}
+		if (displayEndAt != null) {
+			this.displayEndAt = displayEndAt;
+		}
+	}
+
+	public void publish() {
+
+		this.status = NoticeStatus.PUBLISHED;
+	}
+
+	public void draft() {
+
+		this.status = NoticeStatus.DRAFT;
+	}
+
+	public void delete() {
+
+		this.status = NoticeStatus.DELETED;
+	}
+
+	public void increaseViewCount() {
+
+		this.viewCount += 1;
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/domain/Notice.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/domain/Notice.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@Table(name = "notice", schema = "member")
+@Table(name = "notice", schema = "admin")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notice extends BaseEntity {
 

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/domain/NoticeRepository.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/domain/NoticeRepository.java
@@ -1,0 +1,38 @@
+package com.coc.modi.member.admin.notice.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+	@Query("""
+			select n from Notice n
+			where n.status = :status
+			  and (n.displayStartAt is null or n.displayStartAt <= :now)
+			  and (n.displayEndAt is null or n.displayEndAt >= :now)
+			  and (:keyword is null
+				   or lower(n.title) like :keyword
+				   or lower(n.content) like :keyword)
+			""")
+	Page<Notice> findPublishedVisible(@Param("status") NoticeStatus status,
+									  @Param("now") LocalDateTime now,
+									  @Param("keyword") String keyword,
+									  Pageable pageable);
+
+	@Query("""
+			select n from Notice n
+			where n.id = :noticeId
+			  and n.status = :status
+			  and (n.displayStartAt is null or n.displayStartAt <= :now)
+			  and (n.displayEndAt is null or n.displayEndAt >= :now)
+			""")
+	Optional<Notice> findPublishedVisibleById(@Param("noticeId") Long noticeId,
+											  @Param("status") NoticeStatus status,
+											  @Param("now") LocalDateTime now);
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/domain/NoticeStatus.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/domain/NoticeStatus.java
@@ -1,0 +1,7 @@
+package com.coc.modi.member.admin.notice.domain;
+
+public enum NoticeStatus {
+	DRAFT,
+	PUBLISHED,
+	DELETED
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/exception/NoticeException.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/exception/NoticeException.java
@@ -1,0 +1,22 @@
+package com.coc.modi.member.admin.notice.exception;
+
+import com.coc.modi.common.ErrorCode;
+import com.coc.modi.member.member.exception.MemberException;
+
+public class NoticeException extends MemberException {
+
+	public NoticeException(ErrorCode errorCode) {
+
+		super(errorCode);
+	}
+
+	public NoticeException(ErrorCode errorCode, String message) {
+
+		super(errorCode, message);
+	}
+
+	public NoticeException(ErrorCode errorCode, String message, Throwable cause) {
+
+		super(errorCode, message, cause);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/exception/NoticeException.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/exception/NoticeException.java
@@ -1,9 +1,9 @@
 package com.coc.modi.member.admin.notice.exception;
 
 import com.coc.modi.common.ErrorCode;
-import com.coc.modi.member.member.exception.MemberException;
+import com.coc.modi.member.admin.exception.AdminException;
 
-public class NoticeException extends MemberException {
+public class NoticeException extends AdminException {
 
 	public NoticeException(ErrorCode errorCode) {
 

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/exception/NoticeNotFoundException.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/exception/NoticeNotFoundException.java
@@ -1,0 +1,10 @@
+package com.coc.modi.member.admin.notice.exception;
+
+import com.coc.modi.common.ErrorCode;
+public class NoticeNotFoundException extends NoticeException {
+
+	public NoticeNotFoundException(String message) {
+
+		super(ErrorCode.NOTICE_NOT_FOUND, message);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/exception/NoticeNotFoundException.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/exception/NoticeNotFoundException.java
@@ -1,10 +1,11 @@
 package com.coc.modi.member.admin.notice.exception;
 
 import com.coc.modi.common.ErrorCode;
+
 public class NoticeNotFoundException extends NoticeException {
 
 	public NoticeNotFoundException(String message) {
 
-		super(ErrorCode.NOTICE_NOT_FOUND, message);
+		super(ErrorCode.ADMIN_NOTICE_NOT_FOUND, message);
 	}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/presentation/AdminNoticeController.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/presentation/AdminNoticeController.java
@@ -6,7 +6,7 @@ import com.coc.modi.member.admin.notice.application.NoticeService;
 import com.coc.modi.member.admin.notice.application.dto.NoticeResponse;
 import com.coc.modi.member.admin.notice.presentation.dto.NoticeCreateRequest;
 import com.coc.modi.member.admin.notice.presentation.dto.NoticeUpdateRequest;
-import com.coc.modi.member.member.exception.MemberAccessDeniedException;
+import com.coc.modi.member.admin.exception.AdminAccessDeniedException;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -86,7 +86,7 @@ public class AdminNoticeController {
 	private void requireAdmin(CustomMember member) {
 
 		if (member == null || !"ADMIN".equals(member.role())) {
-			throw new MemberAccessDeniedException("관리자 권한이 필요합니다.");
+			throw new AdminAccessDeniedException("관리자 권한이 필요합니다.");
 		}
 	}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/presentation/AdminNoticeController.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/presentation/AdminNoticeController.java
@@ -1,0 +1,92 @@
+package com.coc.modi.member.admin.notice.presentation;
+
+import com.coc.modi.common.ApiResponse;
+import com.coc.modi.common.auth.CustomMember;
+import com.coc.modi.member.admin.notice.application.NoticeService;
+import com.coc.modi.member.admin.notice.application.dto.NoticeResponse;
+import com.coc.modi.member.admin.notice.presentation.dto.NoticeCreateRequest;
+import com.coc.modi.member.admin.notice.presentation.dto.NoticeUpdateRequest;
+import com.coc.modi.member.member.exception.MemberAccessDeniedException;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/notices")
+public class AdminNoticeController {
+
+	private final NoticeService noticeService;
+
+	@PostMapping
+	public ResponseEntity<ApiResponse<NoticeResponse>> createNotice(
+			@AuthenticationPrincipal CustomMember member,
+			@Valid @RequestBody NoticeCreateRequest request
+	) {
+
+		requireAdmin(member);
+		NoticeResponse response = noticeService.createNotice(request.toCommand(member.memberId()));
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(response));
+	}
+
+	@PatchMapping("/{noticeId}")
+	public ResponseEntity<ApiResponse<NoticeResponse>> updateNotice(
+			@AuthenticationPrincipal CustomMember member,
+			@PathVariable Long noticeId,
+			@Valid @RequestBody NoticeUpdateRequest request
+	) {
+
+		requireAdmin(member);
+		NoticeResponse response = noticeService.updateNotice(request.toCommand(noticeId));
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+
+	@DeleteMapping("/{noticeId}")
+	public ResponseEntity<Void> deleteNotice(
+			@AuthenticationPrincipal CustomMember member,
+			@PathVariable Long noticeId
+	) {
+
+		requireAdmin(member);
+		noticeService.deleteNotice(noticeId);
+		return ResponseEntity.noContent().build();
+	}
+
+	@PatchMapping("/{noticeId}/publish")
+	public ResponseEntity<ApiResponse<NoticeResponse>> publishNotice(
+			@AuthenticationPrincipal CustomMember member,
+			@PathVariable Long noticeId
+	) {
+
+		requireAdmin(member);
+		return ResponseEntity.ok(ApiResponse.ok(noticeService.publishNotice(noticeId)));
+	}
+
+	@PatchMapping("/{noticeId}/draft")
+	public ResponseEntity<ApiResponse<NoticeResponse>> draftNotice(
+			@AuthenticationPrincipal CustomMember member,
+			@PathVariable Long noticeId
+	) {
+
+		requireAdmin(member);
+		return ResponseEntity.ok(ApiResponse.ok(noticeService.draftNotice(noticeId)));
+	}
+
+	private void requireAdmin(CustomMember member) {
+
+		if (member == null || !"ADMIN".equals(member.role())) {
+			throw new MemberAccessDeniedException("관리자 권한이 필요합니다.");
+		}
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/presentation/NoticeController.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/presentation/NoticeController.java
@@ -1,0 +1,46 @@
+package com.coc.modi.member.admin.notice.presentation;
+
+import com.coc.modi.common.ApiResponse;
+import com.coc.modi.member.admin.notice.application.NoticeService;
+import com.coc.modi.member.admin.notice.application.dto.NoticeResponse;
+import com.coc.modi.member.admin.notice.application.dto.NoticeSummaryResponse;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notices")
+public class NoticeController {
+
+	private final NoticeService noticeService;
+
+	@GetMapping
+	public ResponseEntity<ApiResponse<Page<NoticeSummaryResponse>>> getNotices(
+			@RequestParam(required = false) String keyword,
+			@PageableDefault(sort = {"pinned", "createdAt"}, direction = Sort.Direction.DESC) Pageable pageable
+	) {
+
+		Page<NoticeSummaryResponse> responses = noticeService.getPublishedNotices(keyword, pageable);
+		return ResponseEntity.ok(ApiResponse.ok(responses));
+	}
+
+	@GetMapping("/{noticeId}")
+	public ResponseEntity<ApiResponse<NoticeResponse>> getNotice(
+			@PathVariable Long noticeId
+	) {
+
+		NoticeResponse response = noticeService.getPublishedNotice(noticeId);
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/presentation/dto/NoticeCreateRequest.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/presentation/dto/NoticeCreateRequest.java
@@ -1,0 +1,34 @@
+package com.coc.modi.member.admin.notice.presentation.dto;
+
+import com.coc.modi.member.admin.notice.application.dto.NoticeCreateCommand;
+import com.coc.modi.member.admin.notice.domain.NoticeStatus;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+
+public record NoticeCreateRequest(
+		@NotBlank(message = "제목은 필수입니다.")
+		@Size(max = 200, message = "제목은 200자 이내여야 합니다.")
+		String title,
+		@NotBlank(message = "내용은 필수입니다.")
+		String content,
+		Boolean pinned,
+		NoticeStatus status,
+		LocalDateTime displayStartAt,
+		LocalDateTime displayEndAt
+) {
+	public NoticeCreateCommand toCommand(Long createdBy) {
+
+		return new NoticeCreateCommand(
+				title,
+				content,
+				status,
+				Boolean.TRUE.equals(pinned),
+				displayStartAt,
+				displayEndAt,
+				createdBy
+		);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/presentation/dto/NoticeUpdateRequest.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/notice/presentation/dto/NoticeUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.coc.modi.member.admin.notice.presentation.dto;
+
+import com.coc.modi.member.admin.notice.application.dto.NoticeUpdateCommand;
+
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+
+public record NoticeUpdateRequest(
+		@Size(max = 200, message = "제목은 200자 이내여야 합니다.")
+		String title,
+		String content,
+		Boolean pinned,
+		LocalDateTime displayStartAt,
+		LocalDateTime displayEndAt
+) {
+	public NoticeUpdateCommand toCommand(Long noticeId) {
+
+		return new NoticeUpdateCommand(
+				noticeId,
+				title,
+				content,
+				pinned,
+				displayStartAt,
+				displayEndAt
+		);
+	}
+}

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/presentation/AdminMemberController.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/presentation/AdminMemberController.java
@@ -5,7 +5,7 @@ import com.coc.modi.common.auth.CustomMember;
 import com.coc.modi.member.admin.application.AdminMemberService;
 import com.coc.modi.member.admin.application.dto.AdminMemberCreateResponse;
 import com.coc.modi.member.admin.presentation.dto.AdminMemberCreateRequest;
-import com.coc.modi.member.member.exception.MemberAccessDeniedException;
+import com.coc.modi.member.admin.exception.AdminAccessDeniedException;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +42,7 @@ public class AdminMemberController {
 	private void requireAdmin(CustomMember member) {
 
 		if (member == null || !"ADMIN".equals(member.role())) {
-			throw new MemberAccessDeniedException("관리자 권한이 필요합니다.");
+			throw new AdminAccessDeniedException("관리자 권한이 필요합니다.");
 		}
 	}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/admin/presentation/AdminMemberController.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/admin/presentation/AdminMemberController.java
@@ -5,6 +5,7 @@ import com.coc.modi.common.auth.CustomMember;
 import com.coc.modi.member.admin.application.AdminMemberService;
 import com.coc.modi.member.admin.application.dto.AdminMemberCreateResponse;
 import com.coc.modi.member.admin.presentation.dto.AdminMemberCreateRequest;
+import com.coc.modi.member.member.exception.MemberAccessDeniedException;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,11 +30,19 @@ public class AdminMemberController {
 			@Valid @RequestBody AdminMemberCreateRequest request
 	) {
 
+		requireAdmin(member);
 		AdminMemberCreateResponse response = adminMemberService.createAdmin(
 				request.toCommand(),
 				member.memberId()
 		);
 
 		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+
+	private void requireAdmin(CustomMember member) {
+
+		if (member == null || !"ADMIN".equals(member.role())) {
+			throw new MemberAccessDeniedException("관리자 권한이 필요합니다.");
+		}
 	}
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/member/domain/MemberRepository.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/member/domain/MemberRepository.java
@@ -1,5 +1,9 @@
 package com.coc.modi.member.member.domain;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository {
@@ -15,4 +19,8 @@ public interface MemberRepository {
 	Member save(Member member);
 	
 	Optional<Member> findById(Long memberId);
+
+	Page<Member> findAll(Pageable pageable);
+
+	List<Member> findByIdIn(List<Long> memberIds);
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/member/infrastructure/MemberJpaRepository.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/member/infrastructure/MemberJpaRepository.java
@@ -4,6 +4,7 @@ import com.coc.modi.member.member.domain.Member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberJpaRepository extends JpaRepository<Member, Long> {
@@ -15,4 +16,6 @@ public interface MemberJpaRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByEmail(String email);
 
 	Optional<Member> findByProviderAndProviderId(String provider, String providerId);
+
+	List<Member> findByIdIn(List<Long> memberIds);
 }

--- a/modi/member-service/src/main/java/com/coc/modi/member/member/infrastructure/MemberRepositoryAdapter.java
+++ b/modi/member-service/src/main/java/com/coc/modi/member/member/infrastructure/MemberRepositoryAdapter.java
@@ -7,6 +7,10 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -49,5 +53,17 @@ public class MemberRepositoryAdapter implements MemberRepository {
 	public Optional<Member> findById(Long memberId) {
 		
 		return memberJpaRepository.findById(memberId);
+	}
+
+	@Override
+	public Page<Member> findAll(Pageable pageable) {
+
+		return memberJpaRepository.findAll(pageable);
+	}
+
+	@Override
+	public List<Member> findByIdIn(List<Long> memberIds) {
+
+		return memberJpaRepository.findByIdIn(memberIds);
 	}
 }

--- a/modi/member-service/src/test/java/com/coc/modi/member/admin/blacklist/presentation/AdminBlacklistControllerTest.java
+++ b/modi/member-service/src/test/java/com/coc/modi/member/admin/blacklist/presentation/AdminBlacklistControllerTest.java
@@ -50,7 +50,7 @@ class AdminBlacklistControllerTest {
 	@Test
 	void getBlacklists_returnsPage() {
 		Page<BlacklistSummaryResponse> page = new PageImpl<>(List.of(summaryFixture()));
-		when(blacklistService.getBlacklists(any(), any(), any())).thenReturn(page);
+		when(blacklistService.getBlacklists(any(), any())).thenReturn(page);
 
 		ResponseEntity<ApiResponse<Page<BlacklistSummaryResponse>>> response =
 				adminBlacklistController.getBlacklists(adminMember(), null, Pageable.unpaged());
@@ -67,7 +67,7 @@ class AdminBlacklistControllerTest {
 
 	@Test
 	void searchByEmail_returnsResponse() {
-		when(blacklistService.searchByEmail(any(), any())).thenReturn(summaryFixture());
+		when(blacklistService.searchByEmail(any())).thenReturn(summaryFixture());
 
 		ResponseEntity<ApiResponse<BlacklistSummaryResponse>> response =
 				adminBlacklistController.searchByEmail(adminMember(), "test@test.com");
@@ -84,7 +84,7 @@ class AdminBlacklistControllerTest {
 
 	@Test
 	void getBlacklistDetail_returnsResponse() {
-		when(blacklistService.getBlacklistDetail(any(), any())).thenReturn(detailFixture());
+		when(blacklistService.getBlacklistDetail(any())).thenReturn(detailFixture());
 
 		ResponseEntity<ApiResponse<BlacklistDetailResponse>> response =
 				adminBlacklistController.getBlacklistDetail(adminMember(), 1L);

--- a/modi/member-service/src/test/java/com/coc/modi/member/admin/blacklist/presentation/AdminBlacklistControllerTest.java
+++ b/modi/member-service/src/test/java/com/coc/modi/member/admin/blacklist/presentation/AdminBlacklistControllerTest.java
@@ -1,0 +1,173 @@
+package com.coc.modi.member.admin.blacklist.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.coc.modi.common.ApiResponse;
+import com.coc.modi.common.auth.CustomMember;
+import com.coc.modi.member.admin.blacklist.application.BlacklistService;
+import com.coc.modi.member.admin.blacklist.application.dto.BlacklistDetailResponse;
+import com.coc.modi.member.admin.blacklist.application.dto.BlacklistReleaseCommand;
+import com.coc.modi.member.admin.blacklist.application.dto.BlacklistSummaryResponse;
+import com.coc.modi.member.admin.blacklist.application.dto.BlacklistSuspendCommand;
+import com.coc.modi.member.admin.blacklist.domain.BlacklistStatus;
+import com.coc.modi.member.admin.blacklist.presentation.dto.BlacklistReleaseRequest;
+import com.coc.modi.member.admin.blacklist.presentation.dto.BlacklistSuspendRequest;
+import com.coc.modi.member.admin.exception.AdminAccessDeniedException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+class AdminBlacklistControllerTest {
+
+	@Mock
+	private BlacklistService blacklistService;
+
+	@InjectMocks
+	private AdminBlacklistController adminBlacklistController;
+
+	@Test
+	void getBlacklists_requiresAdmin() {
+		assertThatThrownBy(() -> adminBlacklistController.getBlacklists(sellerMember(), null, Pageable.unpaged()))
+				.isInstanceOf(AdminAccessDeniedException.class);
+	}
+
+	@Test
+	void getBlacklists_returnsPage() {
+		Page<BlacklistSummaryResponse> page = new PageImpl<>(List.of(summaryFixture()));
+		when(blacklistService.getBlacklists(any(), any(), any())).thenReturn(page);
+
+		ResponseEntity<ApiResponse<Page<BlacklistSummaryResponse>>> response =
+				adminBlacklistController.getBlacklists(adminMember(), null, Pageable.unpaged());
+
+		assertThat(response.getBody().success()).isTrue();
+		assertThat(response.getBody().data().getContent()).hasSize(1);
+	}
+
+	@Test
+	void searchByEmail_requiresAdmin() {
+		assertThatThrownBy(() -> adminBlacklistController.searchByEmail(sellerMember(), "test@test.com"))
+				.isInstanceOf(AdminAccessDeniedException.class);
+	}
+
+	@Test
+	void searchByEmail_returnsResponse() {
+		when(blacklistService.searchByEmail(any(), any())).thenReturn(summaryFixture());
+
+		ResponseEntity<ApiResponse<BlacklistSummaryResponse>> response =
+				adminBlacklistController.searchByEmail(adminMember(), "test@test.com");
+
+		assertThat(response.getBody().success()).isTrue();
+		assertThat(response.getBody().data().email()).isEqualTo("test@test.com");
+	}
+
+	@Test
+	void getBlacklistDetail_requiresAdmin() {
+		assertThatThrownBy(() -> adminBlacklistController.getBlacklistDetail(sellerMember(), 1L))
+				.isInstanceOf(AdminAccessDeniedException.class);
+	}
+
+	@Test
+	void getBlacklistDetail_returnsResponse() {
+		when(blacklistService.getBlacklistDetail(any(), any())).thenReturn(detailFixture());
+
+		ResponseEntity<ApiResponse<BlacklistDetailResponse>> response =
+				adminBlacklistController.getBlacklistDetail(adminMember(), 1L);
+
+		assertThat(response.getBody().success()).isTrue();
+		assertThat(response.getBody().data().memberId()).isEqualTo(1L);
+	}
+
+	@Test
+	void suspend_requiresAdmin() {
+		BlacklistSuspendRequest request = new BlacklistSuspendRequest(1L, "사유", "메모");
+		assertThatThrownBy(() -> adminBlacklistController.suspend(sellerMember(), request))
+				.isInstanceOf(AdminAccessDeniedException.class);
+	}
+
+	@Test
+	void suspend_callsService() {
+		BlacklistSuspendRequest request = new BlacklistSuspendRequest(1L, "사유", "메모");
+		when(blacklistService.suspend(any(BlacklistSuspendCommand.class))).thenReturn(detailFixture());
+
+		ResponseEntity<ApiResponse<BlacklistDetailResponse>> response =
+				adminBlacklistController.suspend(adminMember(), request);
+
+		assertThat(response.getStatusCode().value()).isEqualTo(201);
+		ArgumentCaptor<BlacklistSuspendCommand> captor = ArgumentCaptor.forClass(BlacklistSuspendCommand.class);
+		verify(blacklistService).suspend(captor.capture());
+		assertThat(captor.getValue().createdBy()).isEqualTo(10L);
+	}
+
+	@Test
+	void release_requiresAdmin() {
+		assertThatThrownBy(() -> adminBlacklistController.release(sellerMember(), 1L, null))
+				.isInstanceOf(AdminAccessDeniedException.class);
+	}
+
+	@Test
+	void release_callsService() {
+		BlacklistReleaseRequest request = new BlacklistReleaseRequest("메모");
+		when(blacklistService.release(any(BlacklistReleaseCommand.class))).thenReturn(detailFixture());
+
+		ResponseEntity<ApiResponse<BlacklistDetailResponse>> response =
+				adminBlacklistController.release(adminMember(), 1L, request);
+
+		assertThat(response.getBody().success()).isTrue();
+		ArgumentCaptor<BlacklistReleaseCommand> captor = ArgumentCaptor.forClass(BlacklistReleaseCommand.class);
+		verify(blacklistService).release(captor.capture());
+		assertThat(captor.getValue().releasedBy()).isEqualTo(10L);
+	}
+
+	private CustomMember adminMember() {
+		return new CustomMember(10L, "ADMIN");
+	}
+
+	private CustomMember sellerMember() {
+		return new CustomMember(11L, "SELLER");
+	}
+
+	private BlacklistSummaryResponse summaryFixture() {
+		return new BlacklistSummaryResponse(
+				1L,
+				"test@test.com",
+				"테스트",
+				BlacklistStatus.SUSPENDED,
+				LocalDateTime.now().minusDays(1),
+				LocalDateTime.now().plusDays(6),
+				null
+		);
+	}
+
+	private BlacklistDetailResponse detailFixture() {
+		return new BlacklistDetailResponse(
+				1L,
+				"test@test.com",
+				"테스트",
+				"01012341234",
+				BlacklistStatus.SUSPENDED,
+				"사유",
+				"메모",
+				LocalDateTime.now().minusDays(1),
+				LocalDateTime.now().plusDays(6),
+				null,
+				LocalDateTime.now().minusDays(1),
+				LocalDateTime.now()
+		);
+	}
+}

--- a/modi/member-service/src/test/java/com/coc/modi/member/admin/notice/presentation/AdminNoticeControllerTest.java
+++ b/modi/member-service/src/test/java/com/coc/modi/member/admin/notice/presentation/AdminNoticeControllerTest.java
@@ -15,7 +15,7 @@ import com.coc.modi.member.admin.notice.application.dto.NoticeUpdateCommand;
 import com.coc.modi.member.admin.notice.domain.NoticeStatus;
 import com.coc.modi.member.admin.notice.presentation.dto.NoticeCreateRequest;
 import com.coc.modi.member.admin.notice.presentation.dto.NoticeUpdateRequest;
-import com.coc.modi.member.member.exception.MemberAccessDeniedException;
+import com.coc.modi.member.admin.exception.AdminAccessDeniedException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +39,7 @@ class AdminNoticeControllerTest {
 		NoticeCreateRequest request = new NoticeCreateRequest("제목", "내용", null, null, null, null);
 
 		assertThatThrownBy(() -> adminNoticeController.createNotice(sellerMember(), request))
-				.isInstanceOf(MemberAccessDeniedException.class);
+				.isInstanceOf(AdminAccessDeniedException.class);
 	}
 
 	@Test
@@ -66,7 +66,7 @@ class AdminNoticeControllerTest {
 		NoticeUpdateRequest request = new NoticeUpdateRequest("제목", null, null, null, null);
 
 		assertThatThrownBy(() -> adminNoticeController.updateNotice(sellerMember(), 5L, request))
-				.isInstanceOf(MemberAccessDeniedException.class);
+				.isInstanceOf(AdminAccessDeniedException.class);
 	}
 
 	@Test
@@ -89,7 +89,7 @@ class AdminNoticeControllerTest {
 	@Test
 	void deleteNotice_requiresAdmin() {
 		assertThatThrownBy(() -> adminNoticeController.deleteNotice(sellerMember(), 3L))
-				.isInstanceOf(MemberAccessDeniedException.class);
+				.isInstanceOf(AdminAccessDeniedException.class);
 	}
 
 	@Test
@@ -103,13 +103,13 @@ class AdminNoticeControllerTest {
 	@Test
 	void publishNotice_requiresAdmin() {
 		assertThatThrownBy(() -> adminNoticeController.publishNotice(sellerMember(), 4L))
-				.isInstanceOf(MemberAccessDeniedException.class);
+				.isInstanceOf(AdminAccessDeniedException.class);
 	}
 
 	@Test
 	void draftNotice_requiresAdmin() {
 		assertThatThrownBy(() -> adminNoticeController.draftNotice(sellerMember(), 4L))
-				.isInstanceOf(MemberAccessDeniedException.class);
+				.isInstanceOf(AdminAccessDeniedException.class);
 	}
 
 	@Test

--- a/modi/member-service/src/test/java/com/coc/modi/member/admin/notice/presentation/AdminNoticeControllerTest.java
+++ b/modi/member-service/src/test/java/com/coc/modi/member/admin/notice/presentation/AdminNoticeControllerTest.java
@@ -1,0 +1,161 @@
+package com.coc.modi.member.admin.notice.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.coc.modi.common.ApiResponse;
+import com.coc.modi.common.auth.CustomMember;
+import com.coc.modi.member.admin.notice.application.NoticeService;
+import com.coc.modi.member.admin.notice.application.dto.NoticeCreateCommand;
+import com.coc.modi.member.admin.notice.application.dto.NoticeResponse;
+import com.coc.modi.member.admin.notice.application.dto.NoticeUpdateCommand;
+import com.coc.modi.member.admin.notice.domain.NoticeStatus;
+import com.coc.modi.member.admin.notice.presentation.dto.NoticeCreateRequest;
+import com.coc.modi.member.admin.notice.presentation.dto.NoticeUpdateRequest;
+import com.coc.modi.member.member.exception.MemberAccessDeniedException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class AdminNoticeControllerTest {
+
+	@Mock
+	private NoticeService noticeService;
+
+	@InjectMocks
+	private AdminNoticeController adminNoticeController;
+
+	@Test
+	void createNotice_requiresAdmin() {
+		NoticeCreateRequest request = new NoticeCreateRequest("제목", "내용", null, null, null, null);
+
+		assertThatThrownBy(() -> adminNoticeController.createNotice(sellerMember(), request))
+				.isInstanceOf(MemberAccessDeniedException.class);
+	}
+
+	@Test
+	void createNotice_returnsResponseForAdmin() {
+		NoticeCreateRequest request = new NoticeCreateRequest("제목", "내용", true, null, null, null);
+		NoticeResponse response = responseFixture(1L);
+		when(noticeService.createNotice(any(NoticeCreateCommand.class))).thenReturn(response);
+
+		ResponseEntity<ApiResponse<NoticeResponse>> result =
+				adminNoticeController.createNotice(adminMember(), request);
+
+		assertThat(result.getStatusCode().value()).isEqualTo(201);
+		assertThat(result.getBody().success()).isTrue();
+		assertThat(result.getBody().data().id()).isEqualTo(1L);
+
+		ArgumentCaptor<NoticeCreateCommand> captor = ArgumentCaptor.forClass(NoticeCreateCommand.class);
+		verify(noticeService).createNotice(captor.capture());
+		assertThat(captor.getValue().createdBy()).isEqualTo(10L);
+		assertThat(captor.getValue().pinned()).isTrue();
+	}
+
+	@Test
+	void updateNotice_requiresAdmin() {
+		NoticeUpdateRequest request = new NoticeUpdateRequest("제목", null, null, null, null);
+
+		assertThatThrownBy(() -> adminNoticeController.updateNotice(sellerMember(), 5L, request))
+				.isInstanceOf(MemberAccessDeniedException.class);
+	}
+
+	@Test
+	void updateNotice_callsServiceForAdmin() {
+		NoticeUpdateRequest request = new NoticeUpdateRequest("제목", "내용", false, null, null);
+		NoticeResponse response = responseFixture(2L);
+		when(noticeService.updateNotice(any(NoticeUpdateCommand.class))).thenReturn(response);
+
+		ResponseEntity<ApiResponse<NoticeResponse>> result =
+				adminNoticeController.updateNotice(adminMember(), 2L, request);
+
+		assertThat(result.getBody().success()).isTrue();
+		assertThat(result.getBody().data().id()).isEqualTo(2L);
+
+		ArgumentCaptor<NoticeUpdateCommand> captor = ArgumentCaptor.forClass(NoticeUpdateCommand.class);
+		verify(noticeService).updateNotice(captor.capture());
+		assertThat(captor.getValue().noticeId()).isEqualTo(2L);
+	}
+
+	@Test
+	void deleteNotice_requiresAdmin() {
+		assertThatThrownBy(() -> adminNoticeController.deleteNotice(sellerMember(), 3L))
+				.isInstanceOf(MemberAccessDeniedException.class);
+	}
+
+	@Test
+	void deleteNotice_callsServiceForAdmin() {
+		ResponseEntity<Void> result = adminNoticeController.deleteNotice(adminMember(), 3L);
+
+		assertThat(result.getStatusCode().value()).isEqualTo(204);
+		verify(noticeService).deleteNotice(3L);
+	}
+
+	@Test
+	void publishNotice_requiresAdmin() {
+		assertThatThrownBy(() -> adminNoticeController.publishNotice(sellerMember(), 4L))
+				.isInstanceOf(MemberAccessDeniedException.class);
+	}
+
+	@Test
+	void draftNotice_requiresAdmin() {
+		assertThatThrownBy(() -> adminNoticeController.draftNotice(sellerMember(), 4L))
+				.isInstanceOf(MemberAccessDeniedException.class);
+	}
+
+	@Test
+	void publishNotice_callsServiceForAdmin() {
+		NoticeResponse response = responseFixture(4L);
+		when(noticeService.publishNotice(4L)).thenReturn(response);
+
+		ResponseEntity<ApiResponse<NoticeResponse>> result =
+				adminNoticeController.publishNotice(adminMember(), 4L);
+
+		assertThat(result.getBody().success()).isTrue();
+		verify(noticeService).publishNotice(4L);
+	}
+
+	@Test
+	void draftNotice_callsServiceForAdmin() {
+		NoticeResponse response = responseFixture(5L);
+		when(noticeService.draftNotice(5L)).thenReturn(response);
+
+		ResponseEntity<ApiResponse<NoticeResponse>> result =
+				adminNoticeController.draftNotice(adminMember(), 5L);
+
+		assertThat(result.getBody().success()).isTrue();
+		verify(noticeService).draftNotice(5L);
+	}
+
+	private CustomMember adminMember() {
+		return new CustomMember(10L, "ADMIN");
+	}
+
+	private CustomMember sellerMember() {
+		return new CustomMember(11L, "SELLER");
+	}
+
+	private NoticeResponse responseFixture(Long noticeId) {
+		return new NoticeResponse(
+				noticeId,
+				"제목",
+				"내용",
+				NoticeStatus.DRAFT,
+				false,
+				0L,
+				null,
+				null,
+				null,
+				null
+		);
+	}
+}

--- a/modi/member-service/src/test/java/com/coc/modi/member/admin/notice/presentation/NoticeControllerTest.java
+++ b/modi/member-service/src/test/java/com/coc/modi/member/admin/notice/presentation/NoticeControllerTest.java
@@ -1,0 +1,73 @@
+package com.coc.modi.member.admin.notice.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.coc.modi.common.ApiResponse;
+import com.coc.modi.member.admin.notice.application.NoticeService;
+import com.coc.modi.member.admin.notice.application.dto.NoticeResponse;
+import com.coc.modi.member.admin.notice.application.dto.NoticeSummaryResponse;
+import com.coc.modi.member.admin.notice.domain.NoticeStatus;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+class NoticeControllerTest {
+
+	@Mock
+	private NoticeService noticeService;
+
+	@InjectMocks
+	private NoticeController noticeController;
+
+	@Test
+	void getNotices_returnsPage() {
+		Pageable pageable = PageRequest.of(0, 10);
+		NoticeSummaryResponse summary = new NoticeSummaryResponse(1L, "공지", false, 3L, null);
+		Page<NoticeSummaryResponse> page = new PageImpl<>(List.of(summary), pageable, 1);
+		when(noticeService.getPublishedNotices("공지", pageable)).thenReturn(page);
+
+		ResponseEntity<ApiResponse<Page<NoticeSummaryResponse>>> result =
+				noticeController.getNotices("공지", pageable);
+
+		assertThat(result.getBody().success()).isTrue();
+		assertThat(result.getBody().data().getTotalElements()).isEqualTo(1);
+		verify(noticeService).getPublishedNotices("공지", pageable);
+	}
+
+	@Test
+	void getNotice_returnsResponse() {
+		NoticeResponse response = new NoticeResponse(
+				2L,
+				"제목",
+				"내용",
+				NoticeStatus.PUBLISHED,
+				false,
+				10L,
+				null,
+				null,
+				null,
+				null
+		);
+		when(noticeService.getPublishedNotice(2L)).thenReturn(response);
+
+		ResponseEntity<ApiResponse<NoticeResponse>> result =
+				noticeController.getNotice(2L);
+
+		assertThat(result.getBody().success()).isTrue();
+		assertThat(result.getBody().data().id()).isEqualTo(2L);
+		verify(noticeService).getPublishedNotice(2L);
+	}
+}

--- a/modi/member-service/src/test/java/com/coc/modi/member/admin/presentation/AdminMemberControllerTest.java
+++ b/modi/member-service/src/test/java/com/coc/modi/member/admin/presentation/AdminMemberControllerTest.java
@@ -99,4 +99,22 @@ class AdminMemberControllerTest {
 						.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isForbidden());
 	}
+
+	@Test
+	void create_admin_rejects_non_admin_role() throws Exception {
+
+		AdminMemberCreateRequest request = new AdminMemberCreateRequest(
+				"admin@example.com",
+				"Password!1",
+				"Admin",
+				"010-1234-5678"
+		);
+
+		mockMvc.perform(post("/api/admin/members")
+						.header("X-Member-Id", "2")
+						.header("X-Roles", "SELLER")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isForbidden());
+	}
 }

--- a/modi/modi-gateway/permissions-seed.sql
+++ b/modi/modi-gateway/permissions-seed.sql
@@ -19,6 +19,11 @@ INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('P
 INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('GET', '/member-service/api/members/profile', 'MEMBER');
 INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('PUT', '/member-service/api/members/profile', 'MEMBER');
 INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('POST', '/member-service/api/admin/members', 'ADMIN');
+INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('POST', '/member-service/api/admin/notices', 'ADMIN');
+INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('PATCH', '/member-service/api/admin/notices/{noticeId}', 'ADMIN');
+INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('DELETE', '/member-service/api/admin/notices/{noticeId}', 'ADMIN');
+INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('PATCH', '/member-service/api/admin/notices/{noticeId}/publish', 'ADMIN');
+INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('PATCH', '/member-service/api/admin/notices/{noticeId}/draft', 'ADMIN');
 INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('GET', '/notification-service/api/notifications/stream', 'MEMBER');
 INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('POST', '/product-service/api/images/upload', 'SELLER');
 INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('GET', '/product-service/api/products', 'MEMBER');

--- a/modi/modi-gateway/permissions-seed.sql
+++ b/modi/modi-gateway/permissions-seed.sql
@@ -19,6 +19,11 @@ INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('P
 INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('GET', '/member-service/api/members/profile', 'MEMBER');
 INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('PUT', '/member-service/api/members/profile', 'MEMBER');
 INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('POST', '/member-service/api/admin/members', 'ADMIN');
+INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('GET', '/member-service/api/admin/blacklists', 'ADMIN');
+INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('GET', '/member-service/api/admin/blacklists/search', 'ADMIN');
+INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('GET', '/member-service/api/admin/blacklists/{memberId}', 'ADMIN');
+INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('POST', '/member-service/api/admin/blacklists', 'ADMIN');
+INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('PATCH', '/member-service/api/admin/blacklists/{memberId}/release', 'ADMIN');
 INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('POST', '/member-service/api/admin/notices', 'ADMIN');
 INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('PATCH', '/member-service/api/admin/notices/{noticeId}', 'ADMIN');
 INSERT INTO gateway_endpoint_permission (method, path_pattern, roles) VALUES ('DELETE', '/member-service/api/admin/notices/{noticeId}', 'ADMIN');

--- a/modi/notification-service/src/main/java/com/coc/modi/notification/event/SellerRegistrationApprovedEventListener.java
+++ b/modi/notification-service/src/main/java/com/coc/modi/notification/event/SellerRegistrationApprovedEventListener.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 
 import com.coc.modi.common.NotificationType;
 import com.coc.modi.kafka.event.NotificationEvent;
-import com.coc.modi.kafka.event.SellerApprovedEvent;
+import com.coc.modi.kafka.event.SellerRegistrationApprovedEvent;
 import com.coc.modi.kafka.topic.KafkaTopics;
 import com.coc.modi.notification.application.NotificationApplicationService;
 import com.coc.modi.notification.application.SellerApprovalMailService;
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class SellerApprovedEventListener {
+public class SellerRegistrationApprovedEventListener {
 
 	private static final String TITLE = "판매자 등록 승인";
 	private static final String CONTENT = "판매자 등록이 승인되었습니다.";
@@ -23,19 +23,19 @@ public class SellerApprovedEventListener {
 	private final SellerApprovalMailService sellerApprovalMailService;
 
 	@KafkaListener(
-			topics = KafkaTopics.SELLER_APPROVED,
+			topics = KafkaTopics.SELLER_REGISTRATION_APPROVED,
 			groupId = "notification-service",
 			containerFactory = "notificationKafkaListenerContainerFactory"
 	)
-	public void onSellerApproved(SellerApprovedEvent event) {
+	public void onSellerApproved(SellerRegistrationApprovedEvent event) {
 
 		NotificationEvent notification = NotificationEvent.of(
 				event.memberId(),
 				NotificationType.SELLER_APPROVED.name(),
 				TITLE,
 				CONTENT,
-				"SELLER",
-				event.sellerId().toString()
+				"SELLER_REGISTRATION",
+				event.registrationId().toString()
 		);
 
 		notificationApplicationService.handle(notification);

--- a/modi/notification-service/src/main/java/com/coc/modi/notification/event/SellerRegistrationRejectedEventListener.java
+++ b/modi/notification-service/src/main/java/com/coc/modi/notification/event/SellerRegistrationRejectedEventListener.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 
 import com.coc.modi.common.NotificationType;
 import com.coc.modi.kafka.event.NotificationEvent;
-import com.coc.modi.kafka.event.SellerRejectedEvent;
+import com.coc.modi.kafka.event.SellerRegistrationRejectedEvent;
 import com.coc.modi.kafka.topic.KafkaTopics;
 import com.coc.modi.notification.application.NotificationApplicationService;
 import com.coc.modi.notification.application.SellerApprovalMailService;
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class SellerRejectedEventListener {
+public class SellerRegistrationRejectedEventListener {
 
 	private static final String TITLE = "판매자 등록 거부";
 	private static final String CONTENT = "판매자 등록이 거부되었습니다. 자세한 내용은 고객센터에 문의해주세요.";
@@ -23,19 +23,19 @@ public class SellerRejectedEventListener {
 	private final SellerApprovalMailService sellerApprovalMailService;
 
 	@KafkaListener(
-			topics = KafkaTopics.SELLER_REJECTED,
+			topics = KafkaTopics.SELLER_REGISTRATION_REJECTED,
 			groupId = "notification-service",
 			containerFactory = "notificationKafkaListenerContainerFactory"
 	)
-	public void onSellerRejected(SellerRejectedEvent event) {
+	public void onSellerRejected(SellerRegistrationRejectedEvent event) {
 
 		NotificationEvent notification = NotificationEvent.of(
 				event.memberId(),
 				NotificationType.SELLER_REJECTED.name(),
 				TITLE,
 				CONTENT,
-				"SELLER",
-				event.sellerId().toString()
+				"SELLER_REGISTRATION",
+				event.registrationId().toString()
 		);
 
 		notificationApplicationService.handle(notification);

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/outbox/SellerOutboxEventType.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/outbox/SellerOutboxEventType.java
@@ -3,7 +3,7 @@ package com.coc.modi.seller.outbox;
 import com.coc.modi.kafka.topic.KafkaTopics;
 
 public enum SellerOutboxEventType {
-	SELLER_APPROVED(KafkaTopics.SELLER_APPROVED),
+	SELLER_REGISTRATION_APPROVED(KafkaTopics.SELLER_REGISTRATION_APPROVED),
 	SELLER_REGISTRATION_REJECTED(KafkaTopics.SELLER_REGISTRATION_REJECTED);
 
 	private final String topic;

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/outbox/SellerOutboxEventType.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/outbox/SellerOutboxEventType.java
@@ -4,7 +4,7 @@ import com.coc.modi.kafka.topic.KafkaTopics;
 
 public enum SellerOutboxEventType {
 	SELLER_APPROVED(KafkaTopics.SELLER_APPROVED),
-	SELLER_REJECTED(KafkaTopics.SELLER_REJECTED);
+	SELLER_REGISTRATION_REJECTED(KafkaTopics.SELLER_REGISTRATION_REJECTED);
 
 	private final String topic;
 

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/outbox/SellerOutboxPublisher.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/outbox/SellerOutboxPublisher.java
@@ -3,7 +3,7 @@ package com.coc.modi.seller.outbox;
 import java.util.List;
 
 import com.coc.modi.kafka.event.SellerApprovedEvent;
-import com.coc.modi.kafka.event.SellerRejectedEvent;
+import com.coc.modi.kafka.event.SellerRegistrationRejectedEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -57,10 +57,10 @@ public class SellerOutboxPublisher {
 					.get();
 			return;
 		}
-		if (event.getEventType() == SellerOutboxEventType.SELLER_REJECTED) {
-			SellerRejectedEvent payload = readPayload(event.getPayload(), SellerRejectedEvent.class);
+		if (event.getEventType() == SellerOutboxEventType.SELLER_REGISTRATION_REJECTED) {
+			SellerRegistrationRejectedEvent payload = readPayload(event.getPayload(), SellerRegistrationRejectedEvent.class);
 			kafkaTemplate
-					.send(event.getEventType().getTopic(), payload.sellerId().toString(), payload)
+					.send(event.getEventType().getTopic(), payload.registrationId().toString(), payload)
 					.get();
 			return;
 		}

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/outbox/SellerOutboxPublisher.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/outbox/SellerOutboxPublisher.java
@@ -2,7 +2,7 @@ package com.coc.modi.seller.outbox;
 
 import java.util.List;
 
-import com.coc.modi.kafka.event.SellerApprovedEvent;
+import com.coc.modi.kafka.event.SellerRegistrationApprovedEvent;
 import com.coc.modi.kafka.event.SellerRegistrationRejectedEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,10 +50,11 @@ public class SellerOutboxPublisher {
 
 	private void publishEvent(SellerOutboxEvent event) throws Exception {
 
-		if (event.getEventType() == SellerOutboxEventType.SELLER_APPROVED) {
-			SellerApprovedEvent payload = readPayload(event.getPayload(), SellerApprovedEvent.class);
+		if (event.getEventType() == SellerOutboxEventType.SELLER_REGISTRATION_APPROVED) {
+			SellerRegistrationApprovedEvent payload =
+					readPayload(event.getPayload(), SellerRegistrationApprovedEvent.class);
 			kafkaTemplate
-					.send(event.getEventType().getTopic(), payload.sellerId().toString(), payload)
+					.send(event.getEventType().getTopic(), payload.registrationId().toString(), payload)
 					.get();
 			return;
 		}

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/outbox/SellerOutboxService.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/outbox/SellerOutboxService.java
@@ -1,7 +1,7 @@
 package com.coc.modi.seller.outbox;
 
 import com.coc.modi.kafka.event.SellerApprovedEvent;
-import com.coc.modi.kafka.event.SellerRejectedEvent;
+import com.coc.modi.kafka.event.SellerRegistrationRejectedEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -28,13 +28,13 @@ public class SellerOutboxService {
 		outboxEventRepository.save(outboxEvent);
 	}
 
-	public void enqueueSellerRejected(SellerRejectedEvent event) {
+	public void enqueueSellerRejected(SellerRegistrationRejectedEvent event) {
 
 		String payload = writePayload(event);
 		SellerOutboxEvent outboxEvent = SellerOutboxEvent.create(
-				"SELLER",
-				event.sellerId(),
-				SellerOutboxEventType.SELLER_REJECTED,
+				"SELLER_REGISTRATION",
+				event.registrationId(),
+				SellerOutboxEventType.SELLER_REGISTRATION_REJECTED,
 				payload
 		);
 
@@ -46,7 +46,7 @@ public class SellerOutboxService {
 		try {
 			return objectMapper.writeValueAsString(event);
 		} catch (JsonProcessingException ex) {
-			throw new IllegalStateException("Failed to serialize seller approved event", ex);
+			throw new IllegalStateException("Failed to serialize seller event", ex);
 		}
 	}
 }

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/outbox/SellerOutboxService.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/outbox/SellerOutboxService.java
@@ -1,6 +1,6 @@
 package com.coc.modi.seller.outbox;
 
-import com.coc.modi.kafka.event.SellerApprovedEvent;
+import com.coc.modi.kafka.event.SellerRegistrationApprovedEvent;
 import com.coc.modi.kafka.event.SellerRegistrationRejectedEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -15,13 +15,13 @@ public class SellerOutboxService {
 	private final SellerOutboxEventRepository outboxEventRepository;
 	private final ObjectMapper objectMapper;
 
-	public void enqueueSellerApproved(SellerApprovedEvent event) {
+	public void enqueueSellerApproved(SellerRegistrationApprovedEvent event) {
 
 		String payload = writePayload(event);
 		SellerOutboxEvent outboxEvent = SellerOutboxEvent.create(
-				"SELLER",
-				event.sellerId(),
-				SellerOutboxEventType.SELLER_APPROVED,
+				"SELLER_REGISTRATION",
+				event.registrationId(),
+				SellerOutboxEventType.SELLER_REGISTRATION_APPROVED,
 				payload
 		);
 

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/seller/application/SellerApprovalService.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/seller/application/SellerApprovalService.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import com.coc.modi.kafka.event.SellerApprovedEvent;
+import com.coc.modi.kafka.event.SellerRegistrationApprovedEvent;
 import com.coc.modi.kafka.event.SellerRegistrationRejectedEvent;
 import com.coc.modi.seller.outbox.SellerOutboxService;
 import com.coc.modi.seller.seller.application.dto.SellerRegistrationResponse;
@@ -68,7 +68,7 @@ public class SellerApprovalService {
 					seller.getId(), seller.getMemberId());
 		}
 		sellerOutboxService.enqueueSellerApproved(
-				SellerApprovedEvent.of(seller.getId(), seller.getMemberId(), email)
+				SellerRegistrationApprovedEvent.of(registration.getId(), seller.getMemberId(), email)
 		);
 
 		return SellerRegistrationResponse.from(registration);

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/seller/application/SellerApprovalService.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/seller/application/SellerApprovalService.java
@@ -2,65 +2,106 @@ package com.coc.modi.seller.seller.application;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import com.coc.modi.kafka.event.SellerApprovedEvent;
-import com.coc.modi.kafka.event.SellerRejectedEvent;
+import com.coc.modi.kafka.event.SellerRegistrationRejectedEvent;
 import com.coc.modi.seller.outbox.SellerOutboxService;
-import com.coc.modi.seller.seller.application.dto.SellerDetailResponse;
+import com.coc.modi.seller.seller.application.dto.SellerRegistrationResponse;
 import com.coc.modi.seller.seller.domain.Seller;
 import com.coc.modi.seller.seller.domain.SellerRepository;
-import com.coc.modi.seller.seller.domain.SellerStatus;
-import com.coc.modi.seller.seller.exception.SellerNotFoundException;
+import com.coc.modi.seller.seller.exception.SellerStatusConflictException;
 import com.coc.modi.seller.seller.infrastructure.client.member.MemberClientAdapter;
 import com.coc.modi.seller.seller.infrastructure.client.member.dto.MemberEmailResponse;
+import com.coc.modi.seller.seller.registration.domain.SellerRegistration;
+import com.coc.modi.seller.seller.registration.domain.SellerRegistrationRepository;
+import com.coc.modi.seller.seller.registration.domain.SellerRegistrationStatus;
+import com.coc.modi.seller.seller.registration.exception.SellerRegistrationNotFoundException;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class SellerApprovalService {
 
 	private final SellerRepository sellerRepository;
+	private final SellerRegistrationRepository sellerRegistrationRepository;
 	private final SellerOutboxService sellerOutboxService;
 	private final MemberClientAdapter memberClientAdapter;
 
 	@Transactional
-	public SellerDetailResponse approveSeller(Long sellerId) {
+	public SellerRegistrationResponse approveSeller(Long memberId, Long approvedBy) {
 
-		Seller seller = sellerRepository.findById(sellerId)
-				.orElseThrow(() -> new SellerNotFoundException("판매자를 찾을 수 없습니다. id=" + sellerId));
+		SellerRegistration registration = sellerRegistrationRepository.findByMemberId(memberId)
+				.orElseThrow(() -> new SellerRegistrationNotFoundException("판매자 등록 요청을 찾을 수 없습니다. memberId=" + memberId));
 
-		boolean wasPending = seller.getStatus() == SellerStatus.PENDING;
+		if (registration.getStatus() == SellerRegistrationStatus.APPROVED) {
+			throw new SellerStatusConflictException("seller registration is already approved. memberId=" + memberId);
+		}
+		if (registration.getStatus() != SellerRegistrationStatus.PENDING) {
+			throw new SellerStatusConflictException(
+					"seller registration approval is only allowed from PENDING. status=" + registration.getStatus()
+			);
+		}
+		if (sellerRepository.existsByMemberId(memberId)) {
+			throw new SellerStatusConflictException("seller is already registered. memberId=" + memberId);
+		}
+
+		Seller seller = Seller.create(
+				registration.getMemberId(),
+				registration.getStoreName(),
+				registration.getBizRegNo(),
+				registration.getStorePhone()
+		);
 		seller.approve();
 		sellerRepository.save(seller);
 
-		if (wasPending) {
-			MemberEmailResponse emailResponse = memberClientAdapter.getMemberEmail(seller.getMemberId());
-			sellerOutboxService.enqueueSellerApproved(
-					SellerApprovedEvent.of(seller.getId(), seller.getMemberId(), emailResponse.email())
-			);
-		}
+		registration.approve(approvedBy);
+		sellerRegistrationRepository.save(registration);
 
-		return SellerDetailResponse.from(seller);
+		MemberEmailResponse emailResponse = memberClientAdapter.getMemberEmail(seller.getMemberId());
+		String email = emailResponse != null ? emailResponse.email() : null;
+		if (!StringUtils.hasText(email)) {
+			log.warn("승인 메일 발송을 위한 이메일이 비어있습니다. sellerId={}, memberId={}",
+					seller.getId(), seller.getMemberId());
+		}
+		sellerOutboxService.enqueueSellerApproved(
+				SellerApprovedEvent.of(seller.getId(), seller.getMemberId(), email)
+		);
+
+		return SellerRegistrationResponse.from(registration);
 	}
 
 	@Transactional
-	public SellerDetailResponse rejectSeller(Long sellerId) {
+	public SellerRegistrationResponse rejectSeller(Long memberId) {
 
-		Seller seller = sellerRepository.findById(sellerId)
-				.orElseThrow(() -> new SellerNotFoundException("판매자를 찾을 수 없습니다. id=" + sellerId));
+		SellerRegistration registration = sellerRegistrationRepository.findByMemberId(memberId)
+				.orElseThrow(() -> new SellerRegistrationNotFoundException("판매자 등록 요청을 찾을 수 없습니다. memberId=" + memberId));
 
-		boolean wasPending = seller.getStatus() == SellerStatus.PENDING;
-		seller.reject();
-		sellerRepository.save(seller);
-
-		if (wasPending) {
-			MemberEmailResponse emailResponse = memberClientAdapter.getMemberEmail(seller.getMemberId());
-			sellerOutboxService.enqueueSellerRejected(
-					SellerRejectedEvent.of(seller.getId(), seller.getMemberId(), emailResponse.email())
+		if (registration.getStatus() == SellerRegistrationStatus.REJECTED) {
+			return SellerRegistrationResponse.from(registration);
+		}
+		if (registration.getStatus() != SellerRegistrationStatus.PENDING) {
+			throw new SellerStatusConflictException(
+					"seller registration rejection is only allowed from PENDING. status=" + registration.getStatus()
 			);
 		}
 
-		return SellerDetailResponse.from(seller);
+		registration.reject();
+		sellerRegistrationRepository.save(registration);
+
+		MemberEmailResponse emailResponse = memberClientAdapter.getMemberEmail(registration.getMemberId());
+		String email = emailResponse != null ? emailResponse.email() : null;
+		if (!StringUtils.hasText(email)) {
+			log.warn("거절 메일 발송을 위한 이메일이 비어있습니다. registrationId={}, memberId={}",
+					registration.getId(), registration.getMemberId());
+		}
+		sellerOutboxService.enqueueSellerRejected(
+				SellerRegistrationRejectedEvent.of(registration.getId(), registration.getMemberId(), email)
+		);
+
+		return SellerRegistrationResponse.from(registration);
 	}
 }

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/seller/application/SellerService.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/seller/application/SellerService.java
@@ -8,6 +8,10 @@ import com.coc.modi.seller.seller.application.dto.SellerDetailResponse;
 import com.coc.modi.seller.seller.application.dto.SellerUpdateCommand;
 import com.coc.modi.seller.seller.domain.Seller;
 import com.coc.modi.seller.seller.domain.SellerRepository;
+import com.coc.modi.seller.seller.exception.SellerStatusConflictException;
+import com.coc.modi.seller.seller.registration.domain.SellerRegistration;
+import com.coc.modi.seller.seller.registration.domain.SellerRegistrationRepository;
+import com.coc.modi.seller.seller.registration.domain.SellerRegistrationStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +23,7 @@ public class SellerService {
 
     private final SellerRepository sellerRepository;
     private final SellerRentalService sellerRentalService;
+    private final SellerRegistrationRepository sellerRegistrationRepository;
 	
 	@Transactional(readOnly = true)
     public SellerDetailResponse getSeller(Long sellerId) {
@@ -37,21 +42,33 @@ public class SellerService {
 
     @Transactional
     public String registerSeller(SellerCreateCommand command) {
-		
+
         if (sellerRepository.existsByMemberId(command.memberId())) {
             throw new SellerDuplicateException("이미 등록된 판매자입니다. memberId=" + command.memberId());
         }
 
-        Seller seller = Seller.create(
-                command.memberId(),
-                command.storeName(),
-                command.bizRegNo(),
-                command.storePhone()
-        );
+        SellerRegistration registration = sellerRegistrationRepository.findByMemberId(command.memberId())
+                .map(existing -> {
+                    if (existing.getStatus() == SellerRegistrationStatus.APPROVED) {
+                        throw new SellerStatusConflictException("seller registration is already approved. memberId=" + command.memberId());
+                    }
+                    existing.resubmit(
+                            command.storeName(),
+                            command.bizRegNo(),
+                            command.storePhone()
+                    );
+                    return existing;
+                })
+                .orElseGet(() -> SellerRegistration.create(
+                        command.memberId(),
+                        command.storeName(),
+                        command.bizRegNo(),
+                        command.storePhone()
+                ));
 
-        sellerRepository.save(seller);
+        sellerRegistrationRepository.save(registration);
 
-		return seller.getStatus().name();
+		return registration.getStatus().name();
     }
 
 

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/seller/application/dto/SellerRegistrationResponse.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/seller/application/dto/SellerRegistrationResponse.java
@@ -1,0 +1,28 @@
+package com.coc.modi.seller.seller.application.dto;
+
+import com.coc.modi.seller.seller.registration.domain.SellerRegistration;
+import com.coc.modi.seller.seller.registration.domain.SellerRegistrationStatus;
+
+public record SellerRegistrationResponse(
+		Long registrationId,
+		Long memberId,
+		String storeName,
+		String bizRegNo,
+		String storePhone,
+		SellerRegistrationStatus status,
+		Long approvedBy
+) {
+
+	public static SellerRegistrationResponse from(SellerRegistration registration) {
+
+		return new SellerRegistrationResponse(
+				registration.getId(),
+				registration.getMemberId(),
+				registration.getStoreName(),
+				registration.getBizRegNo(),
+				registration.getStorePhone(),
+				registration.getStatus(),
+				registration.getApprovedBy()
+		);
+	}
+}

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/seller/presentation/admin/SellerApprovalAdminController.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/seller/presentation/admin/SellerApprovalAdminController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.coc.modi.common.ErrorCode;
 import com.coc.modi.common.auth.CustomMember;
 import com.coc.modi.seller.seller.application.SellerApprovalService;
-import com.coc.modi.seller.seller.application.dto.SellerDetailResponse;
+import com.coc.modi.seller.seller.application.dto.SellerRegistrationResponse;
 import com.coc.modi.seller.seller.exception.SellerException;
 
 import lombok.RequiredArgsConstructor;
@@ -21,20 +21,20 @@ public class SellerApprovalAdminController {
 
 	private final SellerApprovalService sellerApprovalService;
 
-	@PatchMapping("/{sellerId}/approve")
-	public SellerDetailResponse approveSeller(@AuthenticationPrincipal CustomMember member,
-											  @PathVariable Long sellerId) {
+	@PatchMapping("/{memberId}/approve")
+	public SellerRegistrationResponse approveSeller(@AuthenticationPrincipal CustomMember member,
+											  @PathVariable Long memberId) {
 		
 		requireAdmin(member);
-		return sellerApprovalService.approveSeller(sellerId);
+		return sellerApprovalService.approveSeller(memberId, member.memberId());
 	}
 
-	@PatchMapping("/{sellerId}/reject")
-	public SellerDetailResponse rejectSeller(@AuthenticationPrincipal CustomMember member,
-											 @PathVariable Long sellerId) {
+	@PatchMapping("/{memberId}/reject")
+	public SellerRegistrationResponse rejectSeller(@AuthenticationPrincipal CustomMember member,
+											 @PathVariable Long memberId) {
 
 		requireAdmin(member);
-		return sellerApprovalService.rejectSeller(sellerId);
+		return sellerApprovalService.rejectSeller(memberId);
 	}
 
 	private void requireAdmin(CustomMember member) {

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/seller/registration/domain/SellerRegistration.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/seller/registration/domain/SellerRegistration.java
@@ -1,0 +1,108 @@
+package com.coc.modi.seller.seller.registration.domain;
+
+import com.coc.modi.common.BaseEntity;
+import com.coc.modi.seller.seller.exception.SellerStatusConflictException;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "seller_registration", schema = "seller")
+public class SellerRegistration extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "member_id", nullable = false, unique = true)
+	private Long memberId;
+
+	@Column(name = "store_name", nullable = false, length = 255)
+	private String storeName;
+
+	@Column(name = "biz_reg_no", length = 50)
+	private String bizRegNo;
+
+	@Column(name = "store_phone", length = 20)
+	private String storePhone;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false, length = 20)
+	private SellerRegistrationStatus status;
+
+	@Column(name = "approved_by")
+	private Long approvedBy;
+
+	@Builder
+	private SellerRegistration(Long memberId,
+							   String storeName,
+							   String bizRegNo,
+							   String storePhone,
+							   SellerRegistrationStatus status,
+							   Long approvedBy) {
+		this.memberId = memberId;
+		this.storeName = storeName;
+		this.bizRegNo = bizRegNo;
+		this.storePhone = storePhone;
+		this.status = status != null ? status : SellerRegistrationStatus.PENDING;
+		this.approvedBy = approvedBy;
+	}
+
+	public static SellerRegistration create(Long memberId,
+											String storeName,
+											String bizRegNo,
+											String storePhone) {
+		return SellerRegistration.builder()
+				.memberId(memberId)
+				.storeName(storeName)
+				.bizRegNo(bizRegNo)
+				.storePhone(storePhone)
+				.status(SellerRegistrationStatus.PENDING)
+				.approvedBy(null)
+				.build();
+	}
+
+	public void resubmit(String storeName,
+						 String bizRegNo,
+						 String storePhone) {
+		this.storeName = storeName;
+		this.bizRegNo = bizRegNo;
+		this.storePhone = storePhone;
+		this.status = SellerRegistrationStatus.PENDING;
+		this.approvedBy = null;
+	}
+
+	public void approve(Long approvedBy) {
+		if (this.status == SellerRegistrationStatus.APPROVED) {
+			return;
+		}
+		if (this.status != SellerRegistrationStatus.PENDING) {
+			throw new SellerStatusConflictException("seller registration approval is only allowed from PENDING. status=" + this.status);
+		}
+		this.status = SellerRegistrationStatus.APPROVED;
+		this.approvedBy = approvedBy;
+	}
+
+	public void reject() {
+		if (this.status == SellerRegistrationStatus.REJECTED) {
+			return;
+		}
+		if (this.status != SellerRegistrationStatus.PENDING) {
+			throw new SellerStatusConflictException("seller registration rejection is only allowed from PENDING. status=" + this.status);
+		}
+		this.status = SellerRegistrationStatus.REJECTED;
+		this.approvedBy = null;
+	}
+}

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/seller/registration/domain/SellerRegistrationRepository.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/seller/registration/domain/SellerRegistrationRepository.java
@@ -1,0 +1,10 @@
+package com.coc.modi.seller.seller.registration.domain;
+
+import java.util.Optional;
+
+public interface SellerRegistrationRepository {
+
+	Optional<SellerRegistration> findByMemberId(Long memberId);
+
+	SellerRegistration save(SellerRegistration registration);
+}

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/seller/registration/domain/SellerRegistrationStatus.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/seller/registration/domain/SellerRegistrationStatus.java
@@ -1,0 +1,7 @@
+package com.coc.modi.seller.seller.registration.domain;
+
+public enum SellerRegistrationStatus {
+	PENDING,
+	APPROVED,
+	REJECTED
+}

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/seller/registration/exception/SellerRegistrationNotFoundException.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/seller/registration/exception/SellerRegistrationNotFoundException.java
@@ -1,0 +1,11 @@
+package com.coc.modi.seller.seller.registration.exception;
+
+import com.coc.modi.common.ErrorCode;
+import com.coc.modi.seller.seller.exception.SellerException;
+
+public class SellerRegistrationNotFoundException extends SellerException {
+
+	public SellerRegistrationNotFoundException(String detailMessage) {
+		super(ErrorCode.SELLER_NOT_FOUND, detailMessage);
+	}
+}

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/seller/registration/infrastructure/SellerRegistrationJpaRepository.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/seller/registration/infrastructure/SellerRegistrationJpaRepository.java
@@ -1,0 +1,12 @@
+package com.coc.modi.seller.seller.registration.infrastructure;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.coc.modi.seller.seller.registration.domain.SellerRegistration;
+
+public interface SellerRegistrationJpaRepository extends JpaRepository<SellerRegistration, Long> {
+
+	Optional<SellerRegistration> findByMemberId(Long memberId);
+}

--- a/modi/seller-service/src/main/java/com/coc/modi/seller/seller/registration/infrastructure/SellerRegistrationRepositoryAdapter.java
+++ b/modi/seller-service/src/main/java/com/coc/modi/seller/seller/registration/infrastructure/SellerRegistrationRepositoryAdapter.java
@@ -1,0 +1,29 @@
+package com.coc.modi.seller.seller.registration.infrastructure;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.coc.modi.seller.seller.registration.domain.SellerRegistration;
+import com.coc.modi.seller.seller.registration.domain.SellerRegistrationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class SellerRegistrationRepositoryAdapter implements SellerRegistrationRepository {
+
+	private final SellerRegistrationJpaRepository sellerRegistrationJpaRepository;
+
+	@Override
+	public Optional<SellerRegistration> findByMemberId(Long memberId) {
+
+		return sellerRegistrationJpaRepository.findByMemberId(memberId);
+	}
+
+	@Override
+	public SellerRegistration save(SellerRegistration registration) {
+
+		return sellerRegistrationJpaRepository.save(registration);
+	}
+}

--- a/modi/seller-service/src/test/java/com/coc/modi/seller/outbox/SellerOutboxPublisherTest.java
+++ b/modi/seller-service/src/test/java/com/coc/modi/seller/outbox/SellerOutboxPublisherTest.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import com.coc.modi.kafka.event.SellerApprovedEvent;
-import com.coc.modi.kafka.event.SellerRejectedEvent;
+import com.coc.modi.kafka.event.SellerRegistrationRejectedEvent;
 import com.coc.modi.kafka.topic.KafkaTopics;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -70,18 +70,18 @@ class SellerOutboxPublisherTest {
 	@Test
 	void publishPendingEvents_handlesRejectedEvent() throws Exception {
 
-		SellerRejectedEvent payload = SellerRejectedEvent.of(2L, 20L, "seller20@example.com");
+		SellerRegistrationRejectedEvent payload = SellerRegistrationRejectedEvent.of(2L, 20L, "seller20@example.com");
 		ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
 		String json = mapper.writeValueAsString(payload);
 		SellerOutboxEvent event = SellerOutboxEvent.create(
-				"SELLER",
+				"SELLER_REGISTRATION",
 				2L,
-				SellerOutboxEventType.SELLER_REJECTED,
+				SellerOutboxEventType.SELLER_REGISTRATION_REJECTED,
 				json
 		);
 
 		when(outboxEventRepository.findPendingForPublish(10)).thenReturn(List.of(event));
-		when(kafkaTemplate.send(eq(KafkaTopics.SELLER_REJECTED), eq("2"), any(SellerRejectedEvent.class)))
+		when(kafkaTemplate.send(eq(KafkaTopics.SELLER_REGISTRATION_REJECTED), eq("2"), any(SellerRegistrationRejectedEvent.class)))
 				.thenReturn(CompletableFuture.<SendResult<String, Object>>completedFuture(null));
 
 		publisher.publishPendingEvents();

--- a/modi/seller-service/src/test/java/com/coc/modi/seller/outbox/SellerOutboxPublisherTest.java
+++ b/modi/seller-service/src/test/java/com/coc/modi/seller/outbox/SellerOutboxPublisherTest.java
@@ -3,7 +3,7 @@ package com.coc.modi.seller.outbox;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import com.coc.modi.kafka.event.SellerApprovedEvent;
+import com.coc.modi.kafka.event.SellerRegistrationApprovedEvent;
 import com.coc.modi.kafka.event.SellerRegistrationRejectedEvent;
 import com.coc.modi.kafka.topic.KafkaTopics;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -48,18 +48,20 @@ class SellerOutboxPublisherTest {
 	@Test
 	void publishPendingEvents_marksSentOnSuccess() throws Exception {
 
-		SellerApprovedEvent payload = SellerApprovedEvent.of(1L, 10L, "seller10@example.com");
+		SellerRegistrationApprovedEvent payload =
+				SellerRegistrationApprovedEvent.of(10L, 110L, "seller10@example.com");
 		ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
 		String json = mapper.writeValueAsString(payload);
 		SellerOutboxEvent event = SellerOutboxEvent.create(
-				"SELLER",
-				1L,
-				SellerOutboxEventType.SELLER_APPROVED,
+				"SELLER_REGISTRATION",
+				10L,
+				SellerOutboxEventType.SELLER_REGISTRATION_APPROVED,
 				json
 		);
 
 		when(outboxEventRepository.findPendingForPublish(10)).thenReturn(List.of(event));
-		when(kafkaTemplate.send(eq(KafkaTopics.SELLER_APPROVED), eq("1"), any(SellerApprovedEvent.class)))
+		when(kafkaTemplate.send(eq(KafkaTopics.SELLER_REGISTRATION_APPROVED), eq("10"),
+				any(SellerRegistrationApprovedEvent.class)))
 				.thenReturn(CompletableFuture.<SendResult<String, Object>>completedFuture(null));
 
 		publisher.publishPendingEvents();
@@ -70,18 +72,20 @@ class SellerOutboxPublisherTest {
 	@Test
 	void publishPendingEvents_handlesRejectedEvent() throws Exception {
 
-		SellerRegistrationRejectedEvent payload = SellerRegistrationRejectedEvent.of(2L, 20L, "seller20@example.com");
+		SellerRegistrationRejectedEvent payload =
+				SellerRegistrationRejectedEvent.of(20L, 220L, "seller20@example.com");
 		ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
 		String json = mapper.writeValueAsString(payload);
 		SellerOutboxEvent event = SellerOutboxEvent.create(
 				"SELLER_REGISTRATION",
-				2L,
+				20L,
 				SellerOutboxEventType.SELLER_REGISTRATION_REJECTED,
 				json
 		);
 
 		when(outboxEventRepository.findPendingForPublish(10)).thenReturn(List.of(event));
-		when(kafkaTemplate.send(eq(KafkaTopics.SELLER_REGISTRATION_REJECTED), eq("2"), any(SellerRegistrationRejectedEvent.class)))
+		when(kafkaTemplate.send(eq(KafkaTopics.SELLER_REGISTRATION_REJECTED), eq("20"),
+				any(SellerRegistrationRejectedEvent.class)))
 				.thenReturn(CompletableFuture.<SendResult<String, Object>>completedFuture(null));
 
 		publisher.publishPendingEvents();

--- a/modi/seller-service/src/test/java/com/coc/modi/seller/seller/application/SellerApprovalServiceTest.java
+++ b/modi/seller-service/src/test/java/com/coc/modi/seller/seller/application/SellerApprovalServiceTest.java
@@ -3,14 +3,16 @@ package com.coc.modi.seller.seller.application;
 import java.util.Optional;
 
 import com.coc.modi.kafka.event.SellerApprovedEvent;
-import com.coc.modi.kafka.event.SellerRejectedEvent;
+import com.coc.modi.kafka.event.SellerRegistrationRejectedEvent;
 import com.coc.modi.seller.outbox.SellerOutboxService;
-import com.coc.modi.seller.seller.application.dto.SellerDetailResponse;
+import com.coc.modi.seller.seller.application.dto.SellerRegistrationResponse;
 import com.coc.modi.seller.seller.domain.Seller;
 import com.coc.modi.seller.seller.domain.SellerRepository;
-import com.coc.modi.seller.seller.domain.SellerStatus;
 import com.coc.modi.seller.seller.infrastructure.client.member.MemberClientAdapter;
 import com.coc.modi.seller.seller.infrastructure.client.member.dto.MemberEmailResponse;
+import com.coc.modi.seller.seller.registration.domain.SellerRegistration;
+import com.coc.modi.seller.seller.registration.domain.SellerRegistrationRepository;
+import com.coc.modi.seller.seller.registration.domain.SellerRegistrationStatus;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +24,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,6 +34,9 @@ class SellerApprovalServiceTest {
 
 	@Mock
 	private SellerRepository sellerRepository;
+
+	@Mock
+	private SellerRegistrationRepository sellerRegistrationRepository;
 
 	@Mock
 	private SellerOutboxService sellerOutboxService;
@@ -44,70 +50,63 @@ class SellerApprovalServiceTest {
 	@Test
 	void approveSeller_enqueuesOutboxWhenPending() {
 
-		Seller seller = Seller.create(10L, "store-10", "biz-10", "010-0000-0000");
-		ReflectionTestUtils.setField(seller, "id", 1L);
+		SellerRegistration registration = SellerRegistration.create(10L, "store-10", "biz-10", "010-0000-0000");
+		ReflectionTestUtils.setField(registration, "id", 100L);
 
-		when(sellerRepository.findById(1L)).thenReturn(Optional.of(seller));
+		when(sellerRegistrationRepository.findByMemberId(10L)).thenReturn(Optional.of(registration));
+		when(sellerRepository.existsByMemberId(10L)).thenReturn(false);
 		when(memberClientAdapter.getMemberEmail(10L)).thenReturn(new MemberEmailResponse(10L, "seller10@example.com"));
+		doAnswer(invocation -> {
+			Seller seller = invocation.getArgument(0);
+			ReflectionTestUtils.setField(seller, "id", 1L);
+			return seller;
+		}).when(sellerRepository).save(any(Seller.class));
 
-		SellerDetailResponse response = sellerApprovalService.approveSeller(1L);
+		SellerRegistrationResponse response = sellerApprovalService.approveSeller(10L, 99L);
 
-		verify(sellerRepository).save(seller);
+		verify(sellerRepository).save(any(Seller.class));
+		verify(sellerRegistrationRepository).save(registration);
 		ArgumentCaptor<SellerApprovedEvent> captor = ArgumentCaptor.forClass(SellerApprovedEvent.class);
 		verify(sellerOutboxService).enqueueSellerApproved(captor.capture());
 		assertThat(captor.getValue().sellerId()).isEqualTo(1L);
 		assertThat(captor.getValue().memberId()).isEqualTo(10L);
 		assertThat(captor.getValue().email()).isEqualTo("seller10@example.com");
-		assertThat(response.status()).isEqualTo(SellerStatus.ACTIVE);
-	}
-
-	@Test
-	void approveSeller_skipsOutboxWhenAlreadyActive() {
-
-		Seller seller = Seller.create(11L, "store-11", "biz-11", "010-0000-0001");
-		seller.approve();
-		ReflectionTestUtils.setField(seller, "id", 2L);
-
-		when(sellerRepository.findById(2L)).thenReturn(Optional.of(seller));
-
-		sellerApprovalService.approveSeller(2L);
-
-		verify(sellerRepository).save(seller);
-		verify(sellerOutboxService, never()).enqueueSellerApproved(any(SellerApprovedEvent.class));
+		assertThat(response.status()).isEqualTo(SellerRegistrationStatus.APPROVED);
+		assertThat(response.approvedBy()).isEqualTo(99L);
 	}
 
 	@Test
 	void rejectSeller_enqueuesOutboxWhenPending() {
 
-		Seller seller = Seller.create(12L, "store-12", "biz-12", "010-0000-0002");
-		ReflectionTestUtils.setField(seller, "id", 3L);
+		SellerRegistration registration = SellerRegistration.create(12L, "store-12", "biz-12", "010-0000-0002");
+		ReflectionTestUtils.setField(registration, "id", 200L);
 
-		when(sellerRepository.findById(3L)).thenReturn(Optional.of(seller));
+		when(sellerRegistrationRepository.findByMemberId(12L)).thenReturn(Optional.of(registration));
 		when(memberClientAdapter.getMemberEmail(12L)).thenReturn(new MemberEmailResponse(12L, "seller12@example.com"));
 
-		SellerDetailResponse response = sellerApprovalService.rejectSeller(3L);
+		SellerRegistrationResponse response = sellerApprovalService.rejectSeller(12L);
 
-		verify(sellerRepository).save(seller);
-		ArgumentCaptor<SellerRejectedEvent> captor = ArgumentCaptor.forClass(SellerRejectedEvent.class);
+		verify(sellerRegistrationRepository).save(registration);
+		ArgumentCaptor<SellerRegistrationRejectedEvent> captor = ArgumentCaptor.forClass(SellerRegistrationRejectedEvent.class);
 		verify(sellerOutboxService).enqueueSellerRejected(captor.capture());
-		assertThat(captor.getValue().sellerId()).isEqualTo(3L);
+		assertThat(captor.getValue().registrationId()).isEqualTo(200L);
 		assertThat(captor.getValue().memberId()).isEqualTo(12L);
 		assertThat(captor.getValue().email()).isEqualTo("seller12@example.com");
-		assertThat(response.status()).isEqualTo(SellerStatus.REJECTED);
+		assertThat(response.status()).isEqualTo(SellerRegistrationStatus.REJECTED);
 	}
 
 	@Test
 	void rejectSeller_skipsOutboxWhenAlreadyRejected() {
 
-		Seller seller = Seller.create(13L, "store-13", "biz-13", "010-0000-0003");
-		seller.reject();
-		ReflectionTestUtils.setField(seller, "id", 4L);
+		SellerRegistration registration = SellerRegistration.create(13L, "store-13", "biz-13", "010-0000-0003");
+		ReflectionTestUtils.setField(registration, "id", 300L);
+		registration.reject();
 
-		when(sellerRepository.findById(4L)).thenReturn(Optional.of(seller));
+		when(sellerRegistrationRepository.findByMemberId(13L)).thenReturn(Optional.of(registration));
 
-		sellerApprovalService.rejectSeller(4L);
+		sellerApprovalService.rejectSeller(13L);
 
-		verify(sellerRepository).save(seller);
-		verify(sellerOutboxService, never()).enqueueSellerRejected(any(SellerRejectedEvent.class));
+		verify(sellerRegistrationRepository, never()).save(any(SellerRegistration.class));
+		verify(sellerOutboxService, never()).enqueueSellerRejected(any(SellerRegistrationRejectedEvent.class));
 	}
 }

--- a/modi/seller-service/src/test/java/com/coc/modi/seller/seller/application/SellerApprovalServiceTest.java
+++ b/modi/seller-service/src/test/java/com/coc/modi/seller/seller/application/SellerApprovalServiceTest.java
@@ -2,7 +2,7 @@ package com.coc.modi.seller.seller.application;
 
 import java.util.Optional;
 
-import com.coc.modi.kafka.event.SellerApprovedEvent;
+import com.coc.modi.kafka.event.SellerRegistrationApprovedEvent;
 import com.coc.modi.kafka.event.SellerRegistrationRejectedEvent;
 import com.coc.modi.seller.outbox.SellerOutboxService;
 import com.coc.modi.seller.seller.application.dto.SellerRegistrationResponse;
@@ -66,9 +66,10 @@ class SellerApprovalServiceTest {
 
 		verify(sellerRepository).save(any(Seller.class));
 		verify(sellerRegistrationRepository).save(registration);
-		ArgumentCaptor<SellerApprovedEvent> captor = ArgumentCaptor.forClass(SellerApprovedEvent.class);
+		ArgumentCaptor<SellerRegistrationApprovedEvent> captor =
+				ArgumentCaptor.forClass(SellerRegistrationApprovedEvent.class);
 		verify(sellerOutboxService).enqueueSellerApproved(captor.capture());
-		assertThat(captor.getValue().sellerId()).isEqualTo(1L);
+		assertThat(captor.getValue().registrationId()).isEqualTo(100L);
 		assertThat(captor.getValue().memberId()).isEqualTo(10L);
 		assertThat(captor.getValue().email()).isEqualTo("seller10@example.com");
 		assertThat(response.status()).isEqualTo(SellerRegistrationStatus.APPROVED);

--- a/modi/seller-service/src/test/java/com/coc/modi/seller/seller/presentation/admin/SellerApprovalAdminControllerTest.java
+++ b/modi/seller-service/src/test/java/com/coc/modi/seller/seller/presentation/admin/SellerApprovalAdminControllerTest.java
@@ -1,8 +1,8 @@
 package com.coc.modi.seller.seller.presentation.admin;
 
 import com.coc.modi.seller.seller.application.SellerApprovalService;
-import com.coc.modi.seller.seller.application.dto.SellerDetailResponse;
-import com.coc.modi.seller.seller.domain.SellerStatus;
+import com.coc.modi.seller.seller.application.dto.SellerRegistrationResponse;
+import com.coc.modi.seller.seller.registration.domain.SellerRegistrationStatus;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,8 +14,6 @@ import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.time.LocalDateTime;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -50,7 +48,7 @@ class SellerApprovalAdminControllerTest {
 	@Test
 	void approveSeller_deniesNonAdmin() throws Exception {
 
-		mockMvc.perform(patch("/api/admin/sellers/{sellerId}/approve", 1L)
+		mockMvc.perform(patch("/api/admin/sellers/{memberId}/approve", 1L)
 						.header("X-Member-Id", "10")
 						.header("X-Roles", "MEMBER"))
 				.andExpect(status().isForbidden());
@@ -61,21 +59,21 @@ class SellerApprovalAdminControllerTest {
 	@Test
 	void approveSeller_allowsAdmin() throws Exception {
 
-		when(sellerApprovalService.approveSeller(1L))
-				.thenReturn(stubResponse(1L, 10L, SellerStatus.ACTIVE));
+		when(sellerApprovalService.approveSeller(1L, 10L))
+				.thenReturn(stubResponse(100L, 1L, SellerRegistrationStatus.APPROVED, 10L));
 
-		mockMvc.perform(patch("/api/admin/sellers/{sellerId}/approve", 1L)
+		mockMvc.perform(patch("/api/admin/sellers/{memberId}/approve", 1L)
 						.header("X-Member-Id", "10")
 						.header("X-Roles", "ADMIN"))
 				.andExpect(status().isOk());
 
-		verify(sellerApprovalService).approveSeller(1L);
+		verify(sellerApprovalService).approveSeller(1L, 10L);
 	}
 
 	@Test
 	void rejectSeller_deniesNonAdmin() throws Exception {
 
-		mockMvc.perform(patch("/api/admin/sellers/{sellerId}/reject", 2L)
+		mockMvc.perform(patch("/api/admin/sellers/{memberId}/reject", 2L)
 						.header("X-Member-Id", "11")
 						.header("X-Roles", "SELLER"))
 				.andExpect(status().isForbidden());
@@ -87,9 +85,9 @@ class SellerApprovalAdminControllerTest {
 	void rejectSeller_allowsAdmin() throws Exception {
 
 		when(sellerApprovalService.rejectSeller(2L))
-				.thenReturn(stubResponse(2L, 11L, SellerStatus.REJECTED));
+				.thenReturn(stubResponse(200L, 2L, SellerRegistrationStatus.REJECTED, null));
 
-		mockMvc.perform(patch("/api/admin/sellers/{sellerId}/reject", 2L)
+		mockMvc.perform(patch("/api/admin/sellers/{memberId}/reject", 2L)
 						.header("X-Member-Id", "11")
 						.header("X-Roles", "ADMIN"))
 				.andExpect(status().isOk());
@@ -97,17 +95,19 @@ class SellerApprovalAdminControllerTest {
 		verify(sellerApprovalService).rejectSeller(2L);
 	}
 
-	private SellerDetailResponse stubResponse(Long sellerId, Long memberId, SellerStatus status) {
+	private SellerRegistrationResponse stubResponse(Long registrationId,
+													Long memberId,
+													SellerRegistrationStatus status,
+													Long approvedBy) {
 
-		return new SellerDetailResponse(
-				sellerId,
+		return new SellerRegistrationResponse(
+				registrationId,
 				memberId,
 				"store",
 				"biz",
 				"010-0000-0000",
 				status,
-				LocalDateTime.now(),
-				LocalDateTime.now()
+				approvedBy
 		);
 	}
 }

--- a/modi/settings.gradle
+++ b/modi/settings.gradle
@@ -13,6 +13,7 @@ include(
         'seller-service',
         'member-service',
         'review-service',
+        'delivery-service',
         'ai-service',
         'notification-service',
         'modi-gateway',


### PR DESCRIPTION
 ## #️⃣ 연관된 이슈

  close #253 

  ## #️⃣ 작업 내용

  - 판매자 등록 테이블 기반 승인/거절 흐름 정리
  - 승인/거절 이벤트 교체 및 registrationId 기준으로 outbox/알림 키 통일
  - 승인 관련 테스트 갱신

  ## #️⃣ 테스트 결과

  - 로컬 테스트

  ## #️⃣ 변경 사항 체크리스트

  - [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
  - [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
  - [ ] 코드 컨벤션에 따라 코드를 작성했나요?
  - [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

  ## #️⃣ 리뷰 요구사항 (선택)

  - 이벤트 스키마 변경과 outbox/알림 키 기준 변경 영향 범위 확인 부탁드립니다.